### PR TITLE
Instructions to use Weave Net for NetworkPolicy

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -50,6 +50,7 @@ as you move through the workshop.
 
 | link:statefulsets[StatefulSets with EBS]
 | link:calico[Network policies with Calico]
+| link:weavenet[Network policies with Weave Net]
 | link:coredns[Using CoreDNS for Service Discovery]
 | link:roles[Managing IAM roles with kube2iam]
 | CI/CD Pipeline

--- a/weavenet/readme.adoc
+++ b/weavenet/readme.adoc
@@ -1,0 +1,315 @@
+= Kubernetes - Enforcing Network Security Policies with Weave Net
+:toc:
+
+Kubernetes Network Policy objects allow for fine-grained network policy enforcement, ensuring that traffic within your Kubernetes cluster can only flow in the direction that you specify.  As an example, if we take a scenario where Kubernetes namespaces are used opt enforce boundaries between products, or even enforce boundaries between different environments (e.g. development vs production), network policies can be configured to ensure no unauthorized network traffic is allowed beyond its boundary.  Think of it as being similar to applying Security Groups in the AWS world.
+
+However, Kubernetes does not come with built-in implementation of Network Policy; this must be provided via a plug-in such as Weave Net.
+
+This exercise will walk you through configuring Weave Net and applying a Network Policy.
+
+== Prerequisites
+
+This chapter uses a cluster with 3 master nodes and 5 worker nodes as described here: link:../cluster-install#multi-master-multi-node-multi-az-gossip-based-cluster[multi-master, multi-node gossip based cluster].
+
+Alternatively, you can create a new cluster and use kops CLI options to specify the networking mode as shown below:
+
+  kops create cluster \
+    --name example2.cluster.k8s.local \
+    --master-count 1 \
+    --node-count 2 \
+    --zones ${AWS_AVAILABILITY_ZONES} \
+    --networking weave \
+    --yes
+
+This will create a 1 master node and 2 worker nodes cluster. It uses `--networking weave` which tells the cluster to use Weave Net instead of the default networking provided by kubenet. Note, the name here is `example2.cluster.k8s.local` instead of the usual `example.cluster.k8s.local` name. This is just to make sure, in case, the two clusters can coexist.
+
+View the cluster configuration using the following command:
+
+  kops edit cluster example2.cluster.k8s.local
+
+This will show the following fragment under `.spec`:
+
+  networking:
+    weave: {}
+
+Rest of the chapter goes with the presumption that you are using an existing cluster.
+
+NOTE: A smaller sized cluster, with 1 master node and 2 worker nodes, is chosen here. This is to minimize the amount of time for rolling update the cluster later. It typically takes 5-6 mins per node for rolling update.
+
+All configuration files for this chapter are in the `weave` directory. Make sure you change to that directory before giving any commands in this chapter.
+
+== Installation
+
+Edit the Kubernetes cluster configuration using the command:
+
+  kops edit cluster example.cluster.k8s.local
+
+By default, Kops uses `kubenet` for networking. This is captured in the configuration file as:
+
+  networking:
+    kubenet: {}
+
+Update the networking configuration to use `weave` by setting the following property:
+
+  networking:
+    weave: {}
+
+View changes that will be applied to the cluster:
+
+  kops update cluster example.cluster.k8s.local
+
+It shows output as:
+
+```
+I1025 15:55:45.512183    3454 apply_cluster.go:420] Gossip DNS: skipping DNS validation
+[...]
+
+Will modify resources:
+  LaunchConfiguration/master-us-east-1d.masters.cluster.k8s.local
+    UserData
+                          ...
+                            - _aws
+                            - _kubernetes_master
+                          + - _networking_cni
+                            channels:
+                            - s3://kubernetes-aws-io/cluster.k8s.local/addons/bootstrap-channel.yaml
+                          ...
+
+
+  LaunchConfiguration/nodes.cluster.k8s.local
+    UserData
+                          ...
+                            - _automatic_upgrades
+                            - _aws
+                          + - _networking_cni
+                            channels:
+                            - s3://kubernetes-aws-io/cluster.k8s.local/addons/bootstrap-channel.yaml
+                          ...
+
+
+  LoadBalancer/api.cluster.k8s.local
+    Lifecycle              <nil> -> Sync
+
+  LoadBalancerAttachment/api-master-us-east-1d
+    Lifecycle              <nil> -> Sync
+
+
+Must specify --yes to apply changes
+```
+
+Apply the changes using the command:
+
+  kops update cluster example.cluster.k8s.local --yes
+
+It shows the output:
+
+```
+I1025 15:56:26.679683    3458 apply_cluster.go:420] Gossip DNS: skipping DNS validation
+[...]
+Kops has set your kubectl context to example.cluster.k8s.local
+
+Cluster changes have been applied to the cloud.
+
+
+Changes may require instances to restart: kops rolling-update cluster
+```
+
+Determine if any of the nodes will require a restart using the command:
+
+  kops rolling-update cluster example.cluster.k8s.local
+
+Output from this command is shown:
+
+```
+$ kops rolling-update cluster example.cluster.k8s.local
+NAME              STATUS      NEEDUPDATE  READY MIN MAX NODES
+master-us-east-1d NeedsUpdate 1           0     1   1   1
+nodes             NeedsUpdate 2           0     2   2   2
+
+Must specify --yes to rolling-update.
+```
+
+The `STATUS` column shows that both master and worker nodes need to be updated.
+
+Perform the rolling update using the command shown:
+
+  kops rolling-update cluster example.cluster.k8s.local --yes
+
+Output from this command is shown:
+
+```
+NAME              STATUS      NEEDUPDATE  READY MIN MAX NODES
+master-us-east-1d NeedsUpdate 1           0     1   1   1
+nodes             NeedsUpdate 2           0     2   2   2
+I1025 16:16:31.978851    3733 instancegroups.go:350] Stopping instance "i-0cdcb2e51e5656b44", node "ip-172-20-44-219.ec2.internal", in AWS ASG "master-us-east-1d.masters.cluster.k8s.local".
+I1025 16:21:32.411639    3733 instancegroups.go:350] Stopping instance "i-060b2c9652e2075ac", node "ip-172-20-54-182.ec2.internal", in AWS ASG "nodes.cluster.k8s.local".
+I1025 16:23:32.973648    3733 instancegroups.go:350] Stopping instance "i-0baffcbc9a758a6c4", node "ip-172-20-94-82.ec2.internal", in AWS ASG "nodes.cluster.k8s.local".
+I1025 16:25:33.784129    3733 rollingupdate.go:174] Rolling update completed!
+```
+
+== Enforcing network isolation
+
+Let's configure Kubernetes Network Policies.
+
+We will create a namespace, deploy some test pods into it, and see the before and after effects of configuring a Network Policy, which will be enforced by Weave Net.
+
+=== Precheck
+
+. Create a namespace:
+
+  $ kubectl create ns ns-1
+  namespace "ns-1" created
+
+. Deploy a container into namespace `ns-1` that will expose an http endpoint, and log all requests it receives. First, create a Deployment, ReplicaSet and Pod using the command:
+
+  $ kubectl run --namespace=ns-1 http-echo --image=solsson/http-echo --env="PORT=80" --port=80
+  deployment "http-echo" created
+
+. Label the pod (we will use labels as part of defining network policies):
+
+  $ kubectl label po --selector=run=http-echo --namespace=ns-1 app=http-echo
+  pod "http-echo-1790350443-z2v7n" labeled
+
+. Create a Service to expose the pod:
+
+  $ kubectl expose --namespace=ns-1 deployment http-echo --port=80
+  service "http-echo" exposed
++
+Monitor the logs of the deployed container by querying the name of the pod defined with the label `run=http-echo`, then passing it to the `kubectl logs` command:
++
+```
+kubectl get po \
+  --selector=run=http-echo \
+  --namespace=ns-1 \
+  -o jsonpath='{.items[*].metadata.name}' | \
+  xargs kubectl logs -f --namespace=ns-1
+```
++
+This command will sit silently until `http-echo` logs a request.
++
+Let's say this is `shell 1`.
++
+. In another shell, say `shell 2`, deploy a second container:
+
+  $ kubectl run \
+    --namespace=ns-1 \
+    -i --tty \
+    busybox \
+    --image=busybox \
+    --restart=Never \
+    -- sh
+  If you don't see a command prompt, try pressing enter.
+  / #
++
+. We will now attempt to call the `http-echo` pod from our `busybox` pod by performing an HTTP POST .  As we have no network policies in place, we should see the following command return successfully with a 200 response, along with a log message being output in the `http-echo` shell window:
++
+```
+/ # wget -S http://http-echo.ns-1.svc.cluster.local/test --post-data '{"message":"hello"}' -O test
+Connecting to http-echo.ns-1.svc.cluster.local (100.71.77.153:80)
+  HTTP/1.1 200 OK
+  X-Powered-By: Express
+  Content-Type: application/json; charset=utf-8
+  Content-Length: 533
+  ETag: W/"215-KyoPN1JoGjQlzW9TxpIay22VPF8"
+  Date: Thu, 26 Oct 2017 00:53:21 GMT
+  Connection: close
+
+test                 100% |*************************************************************************************************|   533   0:00:00 ETA
+```
+HTTP POST request succeeds.
+
+=== Update Weave Net to 2.1.1 in kops 1.7.x
+kops 1.7.x comes with Weave Net 2.0.5 out-of-the-box which does not support the latest network-policy updates for kubernetes 1.7.
+In order to make this work, we need to update Weave Net via:
+
+```
+$ kubectl apply -f templates/weavenet-update.yaml
+[...]
+```
+
+After this, wait for the Weave Net pods to be updated via:
+```
+$ kubectl rollout status ds/weave-net -n kube-system
+Waiting for rollout to finish: 0 out of 3 new pods have been updated...
+Waiting for rollout to finish: 1 out of 3 new pods have been updated...
+Waiting for rollout to finish: 2 out of 3 new pods have been updated...
+Waiting for rollout to finish: 2 of 3 updated pods are available...
+daemon set "weave-net" successfully rolled out
+```
+
+=== Create default network policy
+
+Let's now create a Network Policy, but we will not configure any rules which by default will deny all traffic within the namespace.  Leaving the 2 shells open from the previous steps, run the following in another shell, say `shell 3`:
+
+  $ kubectl create -f templates/deny-all-by-default-network-policy.yaml --namespace=ns-1
+  networkpolicy "deny-all-by-default" created
+
+When running the following command again in shell 2, we should see it eventually timeout and fail (note that rather than waiting for it to time out, you can press `Ctrl` + `C` to quit after about 10 seconds once satisfied that no response will be returned):
+
+```
+/ # wget -S http://http-echo.ns-1.svc.cluster.local/test --post-data '{"message":"hello"}' -O test
+Connecting to http-echo.ns-1.svc.cluster.local (100.64.161.56:80)
+wget: can't connect to remote host (100.64.61.223): Connection timed out
+```
+
+=== Create network policy with a rule
+
+We will now delete the NetworkPolicy that we just created, and create a new NetworkPolicy with a rule defined.  If you `cat templates/allow-network-policy.yaml` you will see the following rule defined:
+
+  spec:
+    podSelector:
+      matchLabels:
+        app: http-echo
+    ingress:
+      - from:
+        - podSelector:
+            matchLabels:
+              app: busybox
+
+The rule above is stating that for every pod that has the label `app: http-echo` defined, allow access to it from pods that have the label `app: busybox` defined.
+
+Run the following in `shell 3` to remove the deny all by default rule, and replace with the above allow rule:
+
+  $ kubectl delete netpol deny-all-by-default --namespace=ns-1
+  networkpolicy "deny-all-by-default" deleted
+  $ kubectl create -f templates/allow-network-policy.yaml --namespace=ns-1
+  networkpolicy "allow" created
+
+If we repeat the following command in `shell 2`, the call should still timeout and fail (again, you can press CTRL-C to quit after 10 seconds rather than waiting for the full timeout to occur):
+
+```
+/ # wget -S http://http-echo.ns-1.svc.cluster.local/test --post-data '{"message":"hello"}' -O test
+Connecting to http-echo.ns-1.svc.cluster.local (100.64.161.56:80)
+wget: can't connect to remote host (100.64.61.223): Connection timed out
+```
+
+Why is this still failing even after creating a rule?  It is failing because we configured the rule so that only pods with the label `app: busybox` are authorized to call pods with the label `app: http-echo`.  Let's go ahead and label our `busybox` pod on `shell 3`:
+
+  / # kubectl label po --selector=run=busybox --namespace=ns-1 app=busybox
+  pod "busybox" labeled
+
+Repeating the test in `shell 2` again should now be successful:
+
+```
+/ # wget -S http://http-echo.ns-1.svc.cluster.local/test --post-data '{"message":"hello"}' -O test
+Connecting to http-echo.ns-1.svc.cluster.local (100.64.161.56:80)
+  HTTP/1.1 200 OK
+  X-Powered-By: Express
+  Content-Type: application/json; charset=utf-8
+  Content-Length: 536
+  ETag: W/"218-xgvU8WZSN+2SEyOX6Q2R/AhLuRM"
+  Date: Thu, 26 Oct 2017 02:15:32 GMT
+  Connection: close
+
+test                100% |*************************************************************************************************|   534   0:00:00 ETA
+```
+
+== Teardown
+
+Remove all the resources and the namespace using the command:
+
+  \ # kubectl delete ns ns-1
+  namespace "ns-1" deleted
+
+== Advanced Topics
+

--- a/weavenet/templates/allow-network-policy.yaml
+++ b/weavenet/templates/allow-network-policy.yaml
@@ -1,0 +1,13 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow
+spec:
+  podSelector:
+    matchLabels:
+      app: http-echo
+  ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+            app: busybox

--- a/weavenet/templates/deny-all-by-default-network-policy.yaml
+++ b/weavenet/templates/deny-all-by-default-network-policy.yaml
@@ -1,0 +1,6 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-all-by-default
+spec:
+  podSelector: {}

--- a/weavenet/templates/weavenet-update.yaml
+++ b/weavenet/templates/weavenet-update.yaml
@@ -1,0 +1,205 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: weave-net
+  labels:
+    name: weave-net
+    role.kubernetes.io/networking: "1"
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - namespaces
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: weave-net
+  labels:
+    name: weave-net
+    role.kubernetes.io/networking: "1"
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: weave-net
+  labels:
+    name: weave-net
+    role.kubernetes.io/networking: "1"
+roleRef:
+  kind: ClusterRole
+  name: weave-net
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: weave-net
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: weave-net
+  namespace: kube-system
+  labels:
+    name: weave-net
+    role.kubernetes.io/networking: "1"
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    resourceNames:
+      - weave-net
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: weave-net
+  namespace: kube-system
+  labels:
+    name: weave-net
+    role.kubernetes.io/networking: "1"
+roleRef:
+  kind: Role
+  name: weave-net
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: weave-net
+    namespace: kube-system
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: weave-net
+  labels:
+    name: weave-net
+    role.kubernetes.io/networking: "1"
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      labels:
+        name: weave-net
+        role.kubernetes.io/networking: "1"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      containers:
+        - name: weave
+          command:
+            - /home/weave/launch.sh
+          env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          image: 'weaveworks/weave-kube:2.1.2'
+          livenessProbe:
+            httpGet:
+              host: 127.0.0.1
+              path: /status
+              port: 6784
+            initialDelaySeconds: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 200Mi
+            limits:
+              memory: 200Mi
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: weavedb
+              mountPath: /weavedb
+            - name: cni-bin
+              mountPath: /host/opt
+            - name: cni-bin2
+              mountPath: /host/home
+            - name: cni-conf
+              mountPath: /host/etc
+            - name: dbus
+              mountPath: /host/var/lib/dbus
+            - name: lib-modules
+              mountPath: /lib/modules
+            - name: xtables-lock
+              mountPath: /run/xtables.lock
+        - name: weave-npc
+          env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          image: 'weaveworks/weave-npc:2.1.2'
+          resources:
+            requests:
+              cpu: 50m
+              memory: 200Mi
+            limits:
+              memory: 200Mi
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: xtables-lock
+              mountPath: /run/xtables.lock
+      hostNetwork: true
+      hostPID: true
+      restartPolicy: Always
+      securityContext:
+        seLinuxOptions: {}
+      serviceAccountName: weave-net
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        - key: CriticalAddonsOnly
+          operator: Exists
+      volumes:
+        - name: weavedb
+          hostPath:
+            path: /var/lib/weave
+        - name: cni-bin
+          hostPath:
+            path: /opt
+        - name: cni-bin2
+          hostPath:
+            path: /home
+        - name: cni-conf
+          hostPath:
+            path: /etc
+        - name: dbus
+          hostPath:
+            path: /var/lib/dbus
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+  updateStrategy:
+    type: RollingUpdate


### PR DESCRIPTION
*Description of changes:*

This adds a second set of instructions for NetworkPolicy, using a different Open Source implementation.

Ideally we would clean this up and have a generic set with call-outs to specific parts, but it'll be ugly until we get all the right versions upstream ( also covered by #236 )

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
