### PR TITLE
show kube-aws-ingress-controller and skipper in action

### DIFF
--- a/ingress-controllers/readme.adoc
+++ b/ingress-controllers/readme.adoc
@@ -241,7 +241,7 @@ Cloud Labels are required to make Kube AWS Ingress Controller work,
 because it has to find the AWS Application Load Balancers it manages
 by AWS Tags, which are called cloud Labels in Kops.
 
-First you set some environment variables to choose AZs to deploy to,
+If not already set, you have to set some environment variables to choose AZs to deploy to,
 your S3 Bucket name for Kops configuration and you Kops cluster name:
 
 

--- a/ingress-controllers/readme.adoc
+++ b/ingress-controllers/readme.adoc
@@ -40,7 +40,7 @@ To configure the Nginx Ingress Controller with RBAC roles use the following comm
 To configure with RBAC:
 
 	curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/rbac.yaml | kubectl apply -f -
-	curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/with-rbac.yaml | kubectl apply -f 
+	curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/with-rbac.yaml | kubectl apply -f
 
 The AWS ELB allows you to apply both L4 and L7 network protocols for ingress behind `Type=LoadBalancer`. Layer 4 uses TCP as the listener protocol for ports 80 and 443. Layer 7 uses HTTP for port 80 and terminates TLS at the ELB.
 
@@ -54,7 +54,7 @@ To configure Layer 7:
 	curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/provider/aws/service-l7.yaml > service-l7.yaml
 
 Edit the the line of the file service-l7.yaml to replace the dummy id with a valid one in the form "arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX"
-	
+
 	kubectl apply -f service-l7.yaml
 	kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/provider/aws/patch-configmap-l7.yaml
 
@@ -211,3 +211,324 @@ of the Ingress resource:
     $ kubectl delete -f https://raw.githubusercontent.com/coreos/alb-ingress-controller/master/examples/default-backend.yaml
 
 Check in the EC2 console to ensure your ALB has been deleted.
+
+== Kube AWS Ingress Controller and Skipper
+
+link:https://github.com/zalando-incubator/kubernetes-on-aws[Kube AWS Ingress Controller]
+creates AWS Application Load Balancer (ALB) that is used to terminate TLS connections and use
+link:https://aws.amazon.com/certificate-manager/[AWS Certificate Manager (ACM)] or
+link:http://docs.aws.amazon.com/IAM/latest/APIReference/Welcome.html[AWS Identity and Access Management (IAM)]
+certificates. ALBs are used to route traffic to an Ingress http router for example
+link:https://github.com/zalando/skipper/[skipper], which routes
+traffic to Kubernetes services and implements
+link:https://zalando.github.io/skipper/dataclients/kubernetes/[advanced features]
+like green-blue deployments, feature toggles, reate limits, circuitbreakers, shadow traffic or A/B tests.
+
+In short the major differences from CoreOS ALB Ingress Controller is:
+
+- it uses Cloudformation instead of API calls
+- does not have routes limitations from AWS
+- automatically finds the best matching ACM and IAM certifacte for your ingress
+- you are free to use an http router imlementation of your choice, which can implement more features like green-blue deployments
+
+For this tutorial I assume you have GNU sed installed, if not read
+commands with `sed` to modify the files according to the `sed` command
+being run. If you are running BSD or MacOS you can use `gsed`.
+
+=== Create Kops cluster with cloud labels
+
+Cloud Labels are required to make Kube AWS Ingress Controller work,
+because it has to find the AWS Application Load Balancers it manages
+by AWS Tags, which are called cloud Labels in Kops.
+
+First you set some environment variables to choose AZs to deploy to,
+your S3 Bucket name for Kops configuration and you Kops cluster name:
+
+
+        export AWS_AVAILABILITY_ZONES=eu-central-1b,eu-central-1c
+        export S3_BUCKET=kops-aws-workshop-<your-name>
+        export KOPS_CLUSTER_NAME=example.cluster.k8s.local
+
+
+The you create the Kops cluster and validate that everything is set up properly.
+
+
+        export KOPS_STATE_STORE=s3://${S3_BUCKET}
+        kops create cluster --name $KOPS_CLUSTER_NAME --zones $AWS_AVAILABILITY_ZONES --cloud-labels kubernetes.io/cluster/$KOPS_CLUSTER_NAME=owned --yes
+        kops validate cluster
+
+
+=== IAM role
+
+This is the effective policy that you need for your EC2 nodes for the
+kube-aws-ingress-controller, which we will use:
+
+```
+{
+  "Effect": "Allow",
+  "Action": [
+    "acm:ListCertificates",
+    "acm:DescribeCertificate",
+    "autoscaling:DescribeAutoScalingGroups",
+    "autoscaling:AttachLoadBalancers",
+    "autoscaling:DetachLoadBalancers",
+    "autoscaling:DetachLoadBalancerTargetGroups",
+    "autoscaling:AttachLoadBalancerTargetGroups",
+    "cloudformation:*",
+    "elasticloadbalancing:*",
+    "elasticloadbalancingv2:*",
+    "ec2:DescribeInstances",
+    "ec2:DescribeSubnets",
+    "ec2:DescribeSecurityGroups",
+    "ec2:DescribeRouteTables",
+    "ec2:DescribeVpcs",
+    "iam:GetServerCertificate",
+    "iam:ListServerCertificates"
+  ],
+  "Resource": [
+    "*"
+  ]
+}
+```
+
+To apply the mentioned policy you have to add link:https://github.com/kubernetes/kops/blob/master/docs/iam_roles.md[additionalPolicies with kops] for your cluster, so edit your cluster.
+
+        kops edit cluster $KOPS_CLUSTER_NAME
+
+and add this to your node policy:
+
+```
+  additionalPolicies:
+    node: |
+      [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "acm:ListCertificates",
+            "acm:DescribeCertificate",
+            "autoscaling:DescribeAutoScalingGroups",
+            "autoscaling:AttachLoadBalancers",
+            "autoscaling:DetachLoadBalancers",
+            "autoscaling:DetachLoadBalancerTargetGroups",
+            "autoscaling:AttachLoadBalancerTargetGroups",
+            "cloudformation:*",
+            "elasticloadbalancing:*",
+            "elasticloadbalancingv2:*",
+            "ec2:DescribeInstances",
+            "ec2:DescribeSubnets",
+            "ec2:DescribeSecurityGroups",
+            "ec2:DescribeRouteTables",
+            "ec2:DescribeVpcs",
+            "iam:GetServerCertificate",
+            "iam:ListServerCertificates"
+          ],
+          "Resource": ["*"]
+        }
+      ]
+```
+
+After that make sure this was applied to your cluster with:
+
+
+        kops update cluster $KOPS_CLUSTER_NAME --yes
+        kops rolling-update cluster
+
+
+=== Security Group for Ingress
+
+To be able to route traffic from ALB to your nodes you need to create
+an Amazon EC2 security group with Kubernetes tags, that allow ingress
+port 80 and 443 from the internet and everything from ALBs to your
+nodes. Tags are used from Kubernetes components to find AWS components
+owned by the cluster. We will do with the AWS cli:
+
+        aws ec2 create-security-group --description ingress.$KOPS_CLUSTER_NAME --group-name ingress.$KOPS_CLUSTER_NAME
+        aws ec2 describe-security-groups --group-names ingress.$KOPS_CLUSTER_NAME
+        sgidingress=$(aws ec2 describe-security-groups --filters Name=group-name,Values=ingress.$KOPS_CLUSTER_NAME | jq '.["SecurityGroups"][0]["GroupId"]' -r)
+        sgidnode=$(aws ec2 describe-security-groups --filters Name=group-name,Values=nodes.$KOPS_CLUSTER_NAME | jq '.["SecurityGroups"][0]["GroupId"]' -r)
+        aws ec2 authorize-security-group-ingress --group-id $sgidingress --protocol tcp --port 443 --cidr 0.0.0.0/0
+        aws ec2 authorize-security-group-ingress --group-id $sgidingress --protocol tcp --port 80 --cidr 0.0.0.0/0
+
+        aws ec2 authorize-security-group-ingress --group-id $sgidnode --protocol all --port -1 --source-group $sgidingress
+        aws ec2 create-tags --resources $sgidingress--tags "kubernetes.io/cluster/id=owned" "kubernetes:application=kube-ingress-aws-controller"
+
+=== AWS Certificate Manager (ACM)
+
+To have TLS termination you can use AWS managed certificates.  If you
+are unsure if you have at least one certificate provisioned use the
+following command to list ACM certificates:
+
+        aws acm list-certificates
+
+If you have one, you can move on to the next section.
+
+To create an ACM certificate, you have to requset a CSR with a domain name that you own in link:https://aws.amazon.com/route53/[route53], for example.org. We will here request one wildcard certificate for example.org:
+
+        aws acm request-certificate --domain-name *.example.org
+
+You will have to successfully do a challenge to show ownership of the
+given domain. In most cases you have to click on a link from an e-mail
+sent by certificates.amazon.com. E-Mail subject will be `Certificate approval for <example.org>`.
+
+If you did the challenge successfully, you can now check the status of
+your certificate. Find the ARN of the new certificate:
+
+        aws acm list-certificates
+
+Describe the certificate and check the Status value:
+
+        aws acm describe-certificate --certificate-arn arn:aws:acm:<snip> | jq '.["Certificate"]["Status"]'
+
+If this is no "ISSUED", your certificate is not valid and you have to fix it.
+To resend the CSR validation e-mail, you can use
+
+        aws acm resend-validation-email
+
+
+=== Install components kube-aws-ingress-controller and skipper
+
+Kube-aws-ingress-controller will be deployed as deployment with 1
+replica, which is ok for production, because it's only configuring
+ALBs.
+
+        REGION=${AWS_AVAILABILITY_ZONES#*,}
+        REGION=${REGION:0:-1}
+        sed -i "s/<REGION>/$REGION/" templates/kube-aws-ingress-controller-deployment.yaml
+        kubectl create -f templates/kube-aws-ingress-controller-deployment.yaml
+
+Skipper will be deployed as daemonset:
+
+        kubectl create -f templates/skipper-ingress-daemonset.yaml
+
+Check, if the installation was successful:
+
+        kops validate cluster
+
+If not and you are sure all steps before were done, please check the logs of the POD, which is not in running state:
+
+        kubectl -n kube-system get pods -l component=ingress
+        kubectl -n kube-system logs <podname>
+
+=== Base features
+
+Deploy one sample application and change the hostname depending on
+your route53 domain and ACM certificate:
+
+        kubectl create -f templates/sample-app-v1.yaml
+        kubectl create -f templates/sample-svc-v1.yaml
+        sed -i "s/<HOSTNAME>/demo-app.example.org/" templates/sample-ing-v1.yaml
+        kubectl create -f templates/sample-ing-v1.yaml
+
+Check if your deployment was successful:
+
+        kubectl get pods,svc -l application=demo
+
+To check if your Ingress created an ALB check the `ADDRESS` column:
+
+        kubectl get ing -l application=demo -o wide
+        NAME           HOSTS                          ADDRESS                                                              PORTS     AGE
+        demo-app-v1   myapp.example.org   example-lb-19tamgwi3atjf-1066321195.us-central-1.elb.amazonaws.com   80        1m
+
+If it is provisioned you can check with curl, http to https redirect is created automatically by Skipper:
+
+        curl -L -H"Host: myapp.example.org" example-lb-19tamgwi3atjf-1066321195.us-central-1.elb.amazonaws.com
+        <body style='color: green; background-color: white;'><h1>Hello!</h1>
+
+Check if Kops dns-controller created a DNS record:
+
+        curl -L myapp.example.org
+        <body style='color: green; background-color: white;'><h1>Hello!</h1>
+
+=== Advanced Features
+
+We assume you have all components running that were applied in `Base features`.
+
+Deploy a second ingress with a feature toggle and rate limit to protect you backend:
+
+        sed -i "s/<HOSTNAME>/demo-app.example.org/" templates/sample-ing-v2.yaml
+        kubectl create -f templates/sample-ing-v2.yaml
+
+Deploy a second sample application:
+
+        kubectl create -f templates/sample-app-v2.yaml
+        kubectl create -f templates/sample-svc-v2.yaml
+
+Now, you can test the feature toggle to access the new v2 application:
+
+        curl "https://myapp.example.org/?version=v2"
+        <body style='color: white; background-color: green;'><h1>Hello AWS!</h1>
+
+If you run this more often, you can easily trigger the rate limit to stop proxying your call to the backend:
+
+        for i in {0..9}; do curl -v "https://myapp.example.org/?version=v2"; done
+
+You should see output similar to:
+
+        *   Trying 52.222.161.4...
+        -------- a lot of TLS output --------
+        > GET /?version=v2 HTTP/1.1
+        > Host: myapp.example.org
+        > User-Agent: curl/7.49.0
+        > Accept: */*
+        >
+        < HTTP/1.1 429 Too Many Requests
+        < Content-Type: text/plain; charset=utf-8
+        < Server: Skipper
+        < X-Content-Type-Options: nosniff
+        < X-Rate-Limit: 60
+        < Date: Mon, 27 Nov 2017 18:19:26 GMT
+        < Content-Length: 18
+        <
+        Too Many Requests
+        * Connection #0 to host myapp.example.org left intact
+
+Your endpoint is now protected.
+
+Next we will show traffic switching.
+Deploy an ingress with traffic switching 80% traffic goes to v1 and
+20% to v2. Change the hostname depending on your route53 domain and
+ACM certificate as before:
+
+        sed -i "s/<HOSTNAME>/demo-app.example.org/" templates/sample-ing-tf.yaml
+        kubectl create -f templates/sample-ing-traffic.yaml
+
+Remove old ingress which will interfere with the new created one:
+
+        kubectl delete -f templates/sample-ing-v1.yaml
+        kubectl delete -f templates/sample-ing-v2.yaml
+
+Check deployments and services (both should be 2)
+
+        kubectl get pods,svc -l application=demo
+
+To check if your Ingress has an ALB check the `ADDRESS` column:
+
+        kubectl get ing -l application=demo -o wide
+        NAME           HOSTS                          ADDRESS                                                              PORTS     AGE
+        demo-traffic-switching   myapp.example.org   example-lb-19tamgwi3atjf-1066321195.us-central-1.elb.amazonaws.com   80        1m
+
+If it is provisioned you can check with curl, http to https redirect is created automatically by Skipper:
+
+        curl -L -H"Host: myapp.example.org" example-lb-19tamgwi3atjf-1066321195.us-central-1.elb.amazonaws.com
+        <body style='color: green; background-color: white;'><h1>Hello!</h1>
+
+Check if Kops dns-controller created a DNS record:
+
+        curl -L myapp.example.org
+        <body style='color: green; background-color: white;'><h1>Hello!</h1>
+
+You can now open your browser at
+link:https://myapp.example.org/[https://myapp.example.org] depending
+on your `hostname` and reload it maybe 5 times to see switching from
+white background to green background. If you modify the
+`zalando.org/backend-weights` annotation you can control the chance
+that you will hit the v1 or the v2 application. Use kubectl annotate to change this:
+
+        kubectl annotate ingress demo-traffic-switching zalando.org/backend-weights='{"demo-app-v1": 20, "demo-app-v2": 80}'
+
+
+=== Cleanup
+
+        for f in templates/sample*; do kubectl delete -f $f; done
+        kubectl delete -f templates/skipper-ingress-daemonset.yaml
+        kubectl delete -f templates/kube-aws-ingress-controller-deployment.yaml

--- a/ingress-controllers/templates/kube-aws-ingress-controller-deployment.yaml
+++ b/ingress-controllers/templates/kube-aws-ingress-controller-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-ingress-aws-controller
+  namespace: kube-system
+  labels:
+    component: ingress
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        component: ingress
+    spec:
+      containers:
+      - name: kube-ingress-aws-controller
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:latest
+        env:
+        - name: AWS_REGION
+          value: <REGION>
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 50m
+            memory: 25Mi

--- a/ingress-controllers/templates/sample-app-v1.yaml
+++ b/ingress-controllers/templates/sample-app-v1.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: demo-app-v1
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        application: demo
+        version: v1
+    spec:
+      containers:
+      - name: skipper-demo
+        image: registry.opensource.zalan.do/pathfinder/skipper:latest
+        args:
+          - "skipper"
+          - "-inline-routes"
+          - "* -> inlineContent(\"<body style='color: green; background-color: white;'><h1>Hello!</h1>\") -> <shunt>"
+        ports:
+        - containerPort: 9090

--- a/ingress-controllers/templates/sample-app-v2.yaml
+++ b/ingress-controllers/templates/sample-app-v2.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: demo-app-v2
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        application: demo
+        version: v2
+    spec:
+      containers:
+      - name: skipper-demo
+        image: registry.opensource.zalan.do/pathfinder/skipper:latest
+        args:
+          - "skipper"
+          - "-inline-routes"
+          - "* -> inlineContent(\"<body style='color: white; background-color: green;'><h1>Hello AWS!</h1>\") -> <shunt>"
+        ports:
+        - containerPort: 9090

--- a/ingress-controllers/templates/sample-ing-traffic.yaml
+++ b/ingress-controllers/templates/sample-ing-traffic.yaml
@@ -1,0 +1,20 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: "demo-traffic-switching"
+  labels:
+    application: demo
+  annotations:
+    zalando.org/backend-weights: |
+      {"demo-app-v1": 80, "demo-app-v2": 20}
+spec:
+  rules:
+  - host: "<HOSTNAME>"
+    http:
+      paths:
+      - backend:
+          serviceName: "demo-app-v1"
+          servicePort: 80
+      - backend:
+          serviceName: "demo-app-v2"
+          servicePort: 80

--- a/ingress-controllers/templates/sample-ing-v1.yaml
+++ b/ingress-controllers/templates/sample-ing-v1.yaml
@@ -1,0 +1,14 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: "demo-v1"
+  labels:
+    application: demo
+spec:
+  rules:
+  - host: "<HOSTNAME>"
+    http:
+      paths:
+      - backend:
+          serviceName: "demo-app-v1"
+          servicePort: 80

--- a/ingress-controllers/templates/sample-ing-v2.yaml
+++ b/ingress-controllers/templates/sample-ing-v2.yaml
@@ -1,0 +1,17 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: "demo-feature-toggle"
+  labels:
+    application: demo
+  annotations:
+    zalando.org/skipper-predicate: QueryParam("version", "^v2$")
+    zalando.org/skipper-filter: ratelimit(2, "1m")
+spec:
+  rules:
+  - host: "<HOSTNAME>"
+    http:
+      paths:
+      - backend:
+          serviceName: "demo-app-v1"
+          servicePort: 80

--- a/ingress-controllers/templates/sample-svc-v1.yaml
+++ b/ingress-controllers/templates/sample-svc-v1.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo-app-v1
+  labels:
+    application: demo
+    version: v1
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 9090
+      name: external
+  selector:
+    application: demo
+    version: v1

--- a/ingress-controllers/templates/sample-svc-v2.yaml
+++ b/ingress-controllers/templates/sample-svc-v2.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo-app-v2
+  labels:
+    application: demo
+    version: v2
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 9090
+      name: external
+  selector:
+    application: demo
+    version: v2

--- a/ingress-controllers/templates/skipper-ingress-daemonset.yaml
+++ b/ingress-controllers/templates/skipper-ingress-daemonset.yaml
@@ -1,0 +1,50 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: skipper-ingress
+  namespace: kube-system
+  labels:
+    component: ingress
+spec:
+  selector:
+    matchLabels:
+      application: skipper-ingress
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      name: skipper-ingress
+      labels:
+        component: ingress
+      hostNetwork: true
+      containers:
+      - name: skipper-ingress
+        image: registry.opensource.zalan.do/pathfinder/skipper:latest
+        ports:
+        - name: ingress-port
+          containerPort: 9999
+          hostPort: 9999
+        args:
+          - "skipper"
+          - "-kubernetes"
+          - "-kubernetes-in-cluster"
+          - "-address=:9999"
+          - "-proxy-preserve-host"
+          - "-serve-host-metrics"
+          - "-enable-ratelimits"
+          - "-experimental-upgrade"
+          - "-metrics-exp-decay-sample"
+          - "-kubernetes-https-redirect=true"
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 25m
+            memory: 25Mi
+        readinessProbe:
+          httpGet:
+            path: /kube-system/healthz
+            port: 9999
+          initialDelaySeconds: 5
+          timeoutSeconds: 5

--- a/readme.adoc
+++ b/readme.adoc
@@ -54,6 +54,7 @@ as you move through the workshop.
 | link:roles[Managing IAM roles with kube2iam]
 | CI/CD Pipeline
 | link:ingress-controllers[ALB Ingress Controller]
+| link:ingress-controllers[Kube AWS Ingress Controller and Skipper]
 | link:ingress-controllers[Nginx Ingress Controller]
 | link:service-mesh[Service Mesh Integration using Linkerd and Istio]
 |===


### PR DESCRIPTION
*Description of changes:*

This adds a new section  [kube-aws-ingress-controller](https://github.com/zalando-incubator/kube-ingress-aws-controller) and [skipper](https://github.com/zalando/skipper) in the ingress-controllers section.

It shows how to integrate with AWS services:
* ALB
* ACM

It shows features applied from ingress and implemented by skipper:
* basic ingress
* automatic redirect from http to https
* feature toggle
* ratelimits
* green-blue deployments



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
