### PR TITLE
Changing Kops to kops

### DIFF
--- a/calico/readme.adoc
+++ b/calico/readme.adoc
@@ -156,7 +156,7 @@ I1025 15:56:30.010284    3458 executor.go:91] Tasks: 68 done / 72 total; 3 can r
 I1025 15:56:30.626483    3458 executor.go:91] Tasks: 71 done / 72 total; 1 can run
 I1025 15:56:30.934673    3458 executor.go:91] Tasks: 72 done / 72 total; 0 can run
 I1025 15:56:31.545416    3458 update_cluster.go:247] Exporting kubecfg for cluster
-Kops has set your kubectl context to example.cluster.k8s.local
+kops has set your kubectl context to example.cluster.k8s.local
 
 Cluster changes have been applied to the cloud.
 

--- a/cluster-install/instance-groups/readme.adoc
+++ b/cluster-install/instance-groups/readme.adoc
@@ -102,7 +102,7 @@ $ kops update cluster --yes
 Using cluster from kubectl context: cluster.k8s.local
 .
 .
-Kops has set your kubectl context to cluster.k8s.local
+kops has set your kubectl context to cluster.k8s.local
 
 Cluster changes have been applied to the cloud.
 
@@ -160,7 +160,7 @@ LaunchConfiguration.
 
     kops edit ig nodes
 
-Change the instance type. Kops supports specific AWS instance types; see the source code here for the latest list:
+Change the instance type. kops supports specific AWS instance types; see the source code here for the latest list:
 https://github.com/kubernetes/kops/blob/709f902c11079345588119ab48c46b7129ef1e44/upup/pkg/fi/cloudup/awsup/machine_types.go#L74
 
 
@@ -217,7 +217,7 @@ $ kops update cluster --yes
 Using cluster from kubectl context: cluster.k8s.local
 .
 .
-Kops has set your kubectl context to cluster.k8s.local
+kops has set your kubectl context to cluster.k8s.local
 
 Cluster changes have been applied to the cloud.
 

--- a/cluster-install/readme.adoc
+++ b/cluster-install/readme.adoc
@@ -1,9 +1,9 @@
-= Create Kubernetes cluster using Kops
+= Create Kubernetes cluster using kops
 :toc:
 
 This tutorial will walk you through how to install a Kubernetes cluster using kops on AWS.
 
-https://github.com/kubernetes/kops[Kops], short for Kubernetes Operations, is a set of tools for installing, operating, and deleting Kubernetes clusters in the cloud. A rolling upgrade of an older version of Kubernetes to a new version can also be performed. It also manages the cluster add-ons. After the cluster is created, the usual kubectl CLI can be used to manage resources in the cluster.
+https://github.com/kubernetes/kops[kops], short for Kubernetes Operations, is a set of tools for installing, operating, and deleting Kubernetes clusters in the cloud. A rolling upgrade of an older version of Kubernetes to a new version can also be performed. It also manages the cluster add-ons. After the cluster is created, the usual kubectl CLI can be used to manage resources in the cluster.
 
 == Install kops
 
@@ -13,7 +13,7 @@ There is no need to download a Kubernetes binary distribution for creating a clu
 
     brew update && brew install kops
 
-If Kops is already installed, then it can be upgraded to the latest version using the following command:
+If kops is already installed, then it can be upgraded to the latest version using the following command:
 
     brew upgrade kops
 
@@ -23,7 +23,7 @@ If Kops is already installed, then it can be upgraded to the latest version usin
     sudo chmod +x kops-linux-amd64
     sudo mv kops-linux-amd64 /usr/local/bin/kops
 
-Kops is available on Mac OSX, Linux or the Windows 10 Linux Subsystem. Complete installation instructions are available at https://github.com/kubernetes/kops#installing.
+kops is available on Mac OSX, Linux or the Windows 10 Linux Subsystem. Complete installation instructions are available at https://github.com/kubernetes/kops#installing.
 
 Check kops version:
 
@@ -36,7 +36,7 @@ In addition, if not already installed, you also need kubectl CLI to manage the r
 
 === Configure kops
 
-Kops uses a public SSH key while creating a cluster. The location of this file defaults to `~/.ssh/id_rsa.pub`. Please generate an SSH key using `ssh-keygen` command.
+kops uses a public SSH key while creating a cluster. The location of this file defaults to `~/.ssh/id_rsa.pub`. Please generate an SSH key using `ssh-keygen` command.
 
 Alternatively, you can use the `--ssh-public-key` option to specify a custom location. More details about kops security can be found in the https://github.com/kubernetes/kops/blob/master/docs/security.md[kops docs].
 
@@ -57,7 +57,7 @@ https://github.com/kubernetes/kops/blob/master/docs/aws.md#setup-iam-user. https
 
 == S3 bucket to store Kubernetes config
 
-Kops needs a "`state store`" to store configuration information of the cluster.  For example, how many nodes in the cluster, the instance type of each node, and the Kubernetes version. The state is stored during the initial cluster creation. Any subsequent changes to the cluster are also persisted to this store. As of now, Amazon S3 is the only supported storage mechanism. Create an S3 bucket and pass that to the kops CLI during cluster creation.
+kops needs a "`state store`" to store configuration information of the cluster.  For example, how many nodes in the cluster, the instance type of each node, and the Kubernetes version. The state is stored during the initial cluster creation. Any subsequent changes to the cluster are also persisted to this store. As of now, Amazon S3 is the only supported storage mechanism. Create an S3 bucket and pass that to the kops CLI during cluster creation.
 
 NOTE: The bucket name must be unique otherwise you will encounter an error on deployment. We will use an example bucket name of `example-state-store-` and add a randomly generated string to the end.
 
@@ -76,7 +76,7 @@ NOTE: The bucket name must be unique otherwise you will encounter an error on de
 
 == Create cluster
 
-The Kops CLI can be used to create a highly available cluster, with multiple master nodes spread across multiple Availability Zones. Workers can be spread across multiple zones as well. Some of the tasks that happen behind the scene during cluster creation are:
+The kops CLI can be used to create a highly available cluster, with multiple master nodes spread across multiple Availability Zones. Workers can be spread across multiple zones as well. Some of the tasks that happen behind the scene during cluster creation are:
 
 - Provisioning EC2 instances
 - Setting up AWS resources such as networks, Auto Scaling groups, IAM users, and security groups
@@ -85,7 +85,7 @@ The Kops CLI can be used to create a highly available cluster, with multiple mas
 When setting up a cluster you have two options on how the nodes in the cluster communicate:
 
 . <<Create a DNS-based Kubernetes cluster, Using DNS>> - Creating a Kubernetes cluster that uses DNS for node discovery requires your own domain (or subdomain) and setting up Route 53 hosted zones. This allows the various Kubernetes components to find and communicate with each other. This is also necessary for kubectl to be able to talk directly with the master.
-. <<Create a gossip-based Kubernetes cluster, Using the gossip protocol>> - Kops has experimental support for a gossip-based cluster. This does not require a  domain, subdomain, or Route53 hosted zone to be registered. A gossip-based cluster is therefore easier and quicker to setup.
+. <<Create a gossip-based Kubernetes cluster, Using the gossip protocol>> - kops has experimental support for a gossip-based cluster. This does not require a  domain, subdomain, or Route53 hosted zone to be registered. A gossip-based cluster is therefore easier and quicker to setup.
 
 You'll need to choose one of the two options. Instructions for both options are provided below, and the examples in the workshop should work with either option. Creating a gossip-based cluster requires less setup and will be used in this workshop, unless otherwise specified.
 
@@ -93,7 +93,7 @@ NOTE: If you're using London region (`eu-west-2`) you need to add `--cloud aws` 
 
 === Create a gossip-based Kubernetes cluster
 
-Kops also has experimental support for a gossip-based cluster. It uses Weave Mesh behind the scenes. This makes the process of creating a Kubernetes cluster using kops DNS-free, and much simpler. This also means a top-level domain or a subdomain is no longer required to create the cluster. To create a cluster using the gossip protocol, indicate this to Kops by using a cluster name with a suffix of `.k8s.local`. In the following steps, we will use example.cluster.k8s.local as a sample gossip cluster name.
+kops also has support for a gossip-based cluster. It uses Weave Mesh behind the scenes. This makes the process of creating a Kubernetes cluster using kops DNS-free, and much simpler. This also means a top-level domain or a subdomain is no longer required to create the cluster. To create a cluster using the gossip protocol, indicate this to by using a cluster name with a suffix of `.k8s.local`. In the following steps, we will use example.cluster.k8s.local as a sample gossip cluster name.
 
 This is a fairly recent feature, so we recommend you continue to use DNS for production clusters. However, setting up a gossip-based cluster allows you to get started rather quickly.
 
@@ -203,7 +203,7 @@ Your output may differ from the one shown here based up on the type of cluster y
 
 === Create a Kubernetes cluster in a private VPC
 
-Kops can create a private Kubernetes cluster, where the master and worker nodes are launched in private subnets in a VPC. This is possible with both Gossip and DNS-based clusters. This reduces the attack surface on your instances by protecting them behind security groups inside private subnets. The services hosted in the cluster can still be exposed via internet-facing ELBs if required. It's necessary to run an overlay network in the Kubernetes cluster when using a private topology. We have used https://www.projectcalico.org/[Calico] below, though other options such as `kopeio-vxlan`, `weave` and `cni` are available.
+kops can create a private Kubernetes cluster, where the master and worker nodes are launched in private subnets in a VPC. This is possible with both Gossip and DNS-based clusters. This reduces the attack surface on your instances by protecting them behind security groups inside private subnets. The services hosted in the cluster can still be exposed via internet-facing ELBs if required. It's necessary to run an overlay network in the Kubernetes cluster when using a private topology. We have used https://www.projectcalico.org/[Calico] below, though other options such as `kopeio-vxlan`, `weave` and `cni` are available.
 
 Create a gossip-based private cluster with master and worker nodes in private subnets:
 

--- a/cluster-scaling/readme.adoc
+++ b/cluster-scaling/readme.adoc
@@ -77,7 +77,7 @@ I1029 14:09:43.034786   15831 executor.go:91] Tasks: 73 done / 81 total; 5 can r
 I1029 14:09:43.868003   15831 executor.go:91] Tasks: 78 done / 81 total; 3 can run
 I1029 14:09:44.655604   15831 executor.go:91] Tasks: 81 done / 81 total; 0 can run
 I1029 14:09:44.991551   15831 update_cluster.go:247] Exporting kubecfg for cluster
-Kops has set your kubectl context to example.cluster.k8s.local
+kops has set your kubectl context to example.cluster.k8s.local
 
 Cluster changes have been applied to the cloud.
 
@@ -104,7 +104,7 @@ No rolling-update required.
 
 Each worker running in your Kubernetes cluster MUST have the necessary IAM Policy attached. If you previously set up your cluster using `kops` you can modify the existing permissions on your worker IAM Role or you can manually create a new policy and attach it to the IAM Role. Both methods are shown below.
 
-=== Using Kops to update the IAM policy
+=== Using kops to update the IAM policy
 
 Use kops to edit the cluster configuration
 
@@ -151,7 +151,7 @@ I1029 15:25:29.512767   21411 executor.go:91] Tasks: 73 done / 81 total; 5 can r
 I1029 15:25:30.338608   21411 executor.go:91] Tasks: 78 done / 81 total; 3 can run
 I1029 15:25:31.189236   21411 executor.go:91] Tasks: 81 done / 81 total; 0 can run
 I1029 15:25:31.586799   21411 update_cluster.go:247] Exporting kubecfg for cluster
-Kops has set your kubectl context to example.cluster.k8s.local
+kops has set your kubectl context to example.cluster.k8s.local
 
 Cluster changes have been applied to the cloud.
 

--- a/cluster-upgrade/readme.adoc
+++ b/cluster-upgrade/readme.adoc
@@ -1,17 +1,17 @@
 = Upgrading Kubernetes cluster
 :toc:
 
-Upgrading Kubernetes cluster on AWS is easy with Kops. In this exercise we will demonstrate upgrading
+Upgrading Kubernetes cluster on AWS is easy with kops. In this exercise we will demonstrate upgrading
 Kubernetes cluster using two methods.
 
 == In-place Upgrade
 
-Upgrading cluster using in-place is easy with Kops. This exercise will setup a Kubernetes cluster
+Upgrading cluster using in-place is easy with kops. This exercise will setup a Kubernetes cluster
 with 1.6.10 version and perform an automatic rolling upgrade to 1.7.2 using kops.
 
 === Create cluster
 
-Review steps to create link:../prereqs.adoc[prereqs] nad make sure `KOPS_STATE_STORE` and `AWS_AVAILABILITY_ZONES` environment variables are set. More details about creating a cluster are at link:../cluster-install[Create Kubernetes cluster using Kops]. 
+Review steps to create link:../prereqs.adoc[prereqs] nad make sure `KOPS_STATE_STORE` and `AWS_AVAILABILITY_ZONES` environment variables are set. More details about creating a cluster are at link:../cluster-install[Create Kubernetes cluster using kops]. 
 
 In this chapter, we'll create a Kubernetes 1.6.10 version cluster as shown:
 
@@ -185,7 +185,7 @@ I1028 18:22:59.756888   10876 executor.go:91] Tasks: 73 done / 81 total; 5 can r
 I1028 18:23:01.154703   10876 executor.go:91] Tasks: 78 done / 81 total; 3 can run
 I1028 18:23:01.890273   10876 executor.go:91] Tasks: 81 done / 81 total; 0 can run
 I1028 18:23:02.196422   10876 update_cluster.go:247] Exporting kubecfg for cluster
-Kops has set your kubectl context to example.cluster.k8s.local
+kops has set your kubectl context to example.cluster.k8s.local
 
 Cluster changes have been applied to the cloud.
 

--- a/config-secrets/readme.adoc
+++ b/config-secrets/readme.adoc
@@ -867,7 +867,7 @@ Service account token, Kubernetes API server address and the certificate used to
   $ kubectl config view -o jsonpath='{.clusters[*].cluster.server}'
   https://api-example-cluster-k8s-l-1dt7vk-41321592.us-east-1.elb.amazonaws.com https://192.168.99.100:8443
 +
-This is the address of API servers currently configured. The first one is for the cluster created by Kops. Second one is for the minikube server, if its running. The first one is relevant for our case.
+This is the address of API servers currently configured. The first one is for the cluster created by kops. Second one is for the minikube server, if its running. The first one is relevant for our case.
 +
 . Extract the certificate
 .. Find the default secret token:

--- a/getting-started/readme.adoc
+++ b/getting-started/readme.adoc
@@ -6,7 +6,7 @@
 
 A Kubernetes cluster can be created on your laptop, VM, cloud provider or a rack of bare metal servers. For development purposes, it's easiest to start with a one-node cluster using https://github.com/kubernetes/minikube[Minikube]. Hosted solutions or cloud-based solutions provide the scalability and higher availability for production purposes. A complete list of solutions to create a Kubernetes cluster is explained at http://kubernetes.io/docs/getting-started-guides/.
 
-This section will explain how to create and shutdown a development Kubernetes cluster using Minikube. The next section will show how to create a highly available cluster on AWS using https://github.com/kubernetes/kops[Kops], as explained in the link:../cluster-install[cluster install] section.
+This section will explain how to create and shutdown a development Kubernetes cluster using Minikube. The next section will show how to create a highly available cluster on AWS using https://github.com/kubernetes/kops[kops], as explained in the link:../cluster-install[cluster install] section.
 
 == Download and Install
 
@@ -441,4 +441,4 @@ The cluster can be shutdown using the following command:
 
 == Create a multi-node cluster on AWS
 
-Though some of the exercises that follow would work on Minikube, let's create a multi-node Kubernetes cluster on AWS as explained in link:../cluster-install[Install Kubernetes cluster using Kops].
+Though some of the exercises that follow would work on Minikube, let's create a multi-node Kubernetes cluster on AWS as explained in link:../cluster-install[Install Kubernetes cluster using kops].

--- a/ingress-controllers/readme.adoc
+++ b/ingress-controllers/readme.adoc
@@ -235,14 +235,14 @@ For this tutorial I assume you have GNU sed installed, if not read
 commands with `sed` to modify the files according to the `sed` command
 being run. If you are running BSD or MacOS you can use `gsed`.
 
-=== Create Kops cluster with cloud labels
+=== Create kops cluster with cloud labels
 
 Cloud Labels are required to make Kube AWS Ingress Controller work,
 because it has to find the AWS Application Load Balancers it manages
-by AWS Tags, which are called cloud Labels in Kops.
+by AWS Tags, which are called cloud Labels in kops.
 
 If not already set, you have to set some environment variables to choose AZs to deploy to,
-your S3 Bucket name for Kops configuration and you Kops cluster name:
+your S3 Bucket name for kops configuration and you kops cluster name:
 
 
         export AWS_AVAILABILITY_ZONES=eu-central-1b,eu-central-1c
@@ -250,7 +250,7 @@ your S3 Bucket name for Kops configuration and you Kops cluster name:
         export KOPS_CLUSTER_NAME=example.cluster.k8s.local
 
 
-The you create the Kops cluster and validate that everything is set up properly.
+The you create the kops cluster and validate that everything is set up properly.
 
 
         export KOPS_STATE_STORE=s3://${S3_BUCKET}
@@ -434,7 +434,7 @@ If it is provisioned you can check with curl, http to https redirect is created 
         curl -L -H"Host: myapp.example.org" example-lb-19tamgwi3atjf-1066321195.us-central-1.elb.amazonaws.com
         <body style='color: green; background-color: white;'><h1>Hello!</h1>
 
-Check if Kops dns-controller created a DNS record:
+Check if kops dns-controller created a DNS record:
 
         curl -L myapp.example.org
         <body style='color: green; background-color: white;'><h1>Hello!</h1>
@@ -512,7 +512,7 @@ If it is provisioned you can check with curl, http to https redirect is created 
         curl -L -H"Host: myapp.example.org" example-lb-19tamgwi3atjf-1066321195.us-central-1.elb.amazonaws.com
         <body style='color: green; background-color: white;'><h1>Hello!</h1>
 
-Check if Kops dns-controller created a DNS record:
+Check if kops dns-controller created a DNS record:
 
         curl -L myapp.example.org
         <body style='color: green; background-color: white;'><h1>Hello!</h1>

--- a/roles/readme.adoc
+++ b/roles/readme.adoc
@@ -22,7 +22,7 @@ All configuration files for this chapter are in the `roles` directory.
 
 == IAM Roles for master nodes
 
-Kubernetes cluster created using kops has two IAM roles - one for all master nodes and one for all worker nodes. The master IAM role is associated with a number of policies related to EC2, Elastic Load Balancer (ELB), EC2 Container Registry (ECR), Route53, and Key Management Service (KMS). The worker nodes require a number of EC2, ECR, and Route53 policies applied. Kops automatically configures these roles and policies for you (see link:https://github.com/kubernetes/kops/blob/master/docs/iam_roles.md[here] for a full list).
+Kubernetes cluster created using kops has two IAM roles - one for all master nodes and one for all worker nodes. The master IAM role is associated with a number of policies related to EC2, Elastic Load Balancer (ELB), EC2 Container Registry (ECR), Route53, and Key Management Service (KMS). The worker nodes require a number of EC2, ECR, and Route53 policies applied. kops automatically configures these roles and policies for you (see link:https://github.com/kubernetes/kops/blob/master/docs/iam_roles.md[here] for a full list).
 
 These policies may be augmented via `kops`.  For example, to allow all nodes ElasticSearch access, perform the following steps:
 


### PR DESCRIPTION
I know it is a nitpick, but we care about our branding. Your docs
helped me find a typo that I have seen 100s of times.  I have a PR in to
fix the Kops type with the kubectl export message.

Also, removed the word experimental with gossip.  We have users running production clusters using gossip.

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
