### PR TITLE
Refactor getting-started and cluster-install; Separate out minikube instructions

### DIFF
--- a/cluster-install/readme.adoc
+++ b/cluster-install/readme.adoc
@@ -23,7 +23,8 @@ If kops is already installed, then it can be upgraded to the latest version usin
     sudo chmod +x kops-linux-amd64
     sudo mv kops-linux-amd64 /usr/local/bin/kops
 
-kops is available on Mac OSX, Linux or the Windows 10 Linux Subsystem. Complete installation instructions are available at https://github.com/kubernetes/kops#installing.
+kops is available on Mac OSX, Linux or the Windows 10 Linux Subsystem. 
+Complete installation instructions are available at https://github.com/kubernetes/kops#installing.
 
 Check kops version:
 
@@ -93,9 +94,9 @@ NOTE: If you're using London region (`eu-west-2`) you need to add `--cloud aws` 
 
 === Create a gossip-based Kubernetes cluster
 
-kops also has support for a gossip-based cluster. It uses Weave Mesh behind the scenes. This makes the process of creating a Kubernetes cluster using kops DNS-free, and much simpler. This also means a top-level domain or a subdomain is no longer required to create the cluster. To create a cluster using the gossip protocol, indicate this to by using a cluster name with a suffix of `.k8s.local`. In the following steps, we will use example.cluster.k8s.local as a sample gossip cluster name.
+kops supports for a gossip-based cluster, which uses Weave Mesh behind the scenes. This makes the process of creating a Kubernetes cluster using kops DNS-free, and therefore much simpler. This also means a top-level domain or a subdomain is no longer required to create the cluster. To create a cluster using the gossip protocol, indicate this to by using a cluster name with a suffix of `.k8s.local`. In the following steps, we will use example.cluster.k8s.local as a sample gossip cluster name. You may choose a different name as long as it ends with `.k8s.local`.
 
-This is a fairly recent feature, so we recommend you continue to use DNS for production clusters. However, setting up a gossip-based cluster allows you to get started rather quickly.
+This is a fairly recent feature, so we recommend you continue to use DNS for production clusters. Information on setting up a DNS-based cluster can be found at the bottom of this page in the Appendix. However, setting up a gossip-based cluster allows you to get started quickly.
 
 We show two examples of creating gossip-based clusters below. You can choose whether to create a single-master or multi-master cluster. Workshop exercises will work on both types of cluster.
 
@@ -203,7 +204,7 @@ Your output may differ from the one shown here based up on the type of cluster y
 
 === Create a Kubernetes cluster in a private VPC
 
-kops can create a private Kubernetes cluster, where the master and worker nodes are launched in private subnets in a VPC. This is possible with both Gossip and DNS-based clusters. This reduces the attack surface on your instances by protecting them behind security groups inside private subnets. The services hosted in the cluster can still be exposed via internet-facing ELBs if required. It's necessary to run an overlay network in the Kubernetes cluster when using a private topology. We have used https://www.projectcalico.org/[Calico] below, though other options such as `kopeio-vxlan`, `weave` and `cni` are available.
+kops can create a private Kubernetes cluster, where the master and worker nodes are launched in private subnets in a VPC. This is possible with both gossip-based and DNS-based clusters. This reduces the attack surface on your instances by protecting them behind security groups inside private subnets. The services hosted in the cluster can still be exposed via internet-facing ELBs if required. It is necessary to run an overlay network in the Kubernetes cluster when using a private topology. We have used https://www.projectcalico.org/[Calico] below, though other options such as `kopeio-vxlan`, `weave` and `cni` are available.
 
 Create a gossip-based private cluster with master and worker nodes in private subnets:
 

--- a/cluster-install/readme.adoc
+++ b/cluster-install/readme.adoc
@@ -122,7 +122,7 @@ NOTE: If you're using London region (`eu-west-2`) you need to add `--cloud aws` 
 
 === Create a gossip-based Kubernetes cluster
 
-kops supports creating a gossip-based cluster, which uses Weave Mesh behind the scenes. This makes the process of creating a Kubernetes cluster using kops DNS-free, and therefore much simpler. This also means a top-level domain or a subdomain is no longer required to create the cluster. To create a cluster using the gossip protocol, indicate this to by using a cluster name with a suffix of `.k8s.local`. In the following steps, we will use example.cluster.k8s.local as a sample gossip cluster name. You may choose a different name as long as it ends with `.k8s.local`.
+kops supports creating a gossip-based cluster, which uses https://github.com/weaveworks/mesh[Weave Mesh] behind the scenes. This makes the process of creating a Kubernetes cluster using kops DNS-free, and therefore much simpler. This also means a top-level domain or a subdomain is no longer required to create the cluster. To create a cluster using the gossip protocol, indicate this to by using a cluster name with a suffix of `.k8s.local`. In the following steps, we will use example.cluster.k8s.local as a sample gossip cluster name. You may choose a different name as long as it ends with `.k8s.local`.
 
 This is a fairly recent feature, so we recommend you continue to use DNS for production clusters. Information on setting up a DNS-based cluster can be found at the bottom of this page in the Appendix. However, setting up a gossip-based cluster allows you to get started quickly.
 

--- a/cluster-install/readme.adoc
+++ b/cluster-install/readme.adoc
@@ -19,7 +19,7 @@ If kops is already installed, then it can be upgraded to the latest version usin
 
     brew upgrade kops
 
-==== Linux / Windows 10 Linux Subsystem:
+==== Linux / Windows 10 Linux Subsystem
 
     wget https://github.com/kubernetes/kops/releases/download/1.7.1/kops-linux-amd64
     sudo chmod +x kops-linux-amd64

--- a/cluster-install/readme.adoc
+++ b/cluster-install/readme.adoc
@@ -1,9 +1,11 @@
 = Create Kubernetes cluster using kops
 :toc:
 
-This tutorial will walk you through how to install a Kubernetes cluster using kops on AWS.
+This tutorial will walk you through how to install a Kubernetes cluster on AWS using kops.
 
-https://github.com/kubernetes/kops[kops], short for Kubernetes Operations, is a set of tools for installing, operating, and deleting Kubernetes clusters in the cloud. A rolling upgrade of an older version of Kubernetes to a new version can also be performed. It also manages the cluster add-ons. After the cluster is created, the usual kubectl CLI can be used to manage resources in the cluster.
+https://github.com/kubernetes/kops[kops], short for Kubernetes Operations, is a set of tools for installing, operating, and deleting Kubernetes clusters in the cloud. It can also perform rolling upgrades from older versions of Kubernetes to newer ones. kops also manages the cluster add-ons. After the cluster is created, the usual link:getting-started[kubectl CLI] can be used to manage resources in the cluster.
+
+kops is available on Mac OSX, Linux, or the Windows 10 Linux Subsystem. 
 
 == Install kops
 
@@ -17,14 +19,14 @@ If kops is already installed, then it can be upgraded to the latest version usin
 
     brew upgrade kops
 
-==== Linux:
+==== Linux / Windows 10 Linux Subsystem:
 
     wget https://github.com/kubernetes/kops/releases/download/1.7.1/kops-linux-amd64
     sudo chmod +x kops-linux-amd64
     sudo mv kops-linux-amd64 /usr/local/bin/kops
 
-kops is available on Mac OSX, Linux or the Windows 10 Linux Subsystem. 
-Complete installation instructions are available at https://github.com/kubernetes/kops#installing.
+
+Complete installation instructions are available https://github.com/kubernetes/kops#installing[here].
 
 Check kops version:
 
@@ -33,19 +35,45 @@ Check kops version:
 
 Latest and early versions of kops can be downloaded from https://github.com/kubernetes/kops/releases.
 
-In addition, if not already installed, you also need kubectl CLI to manage the resources on Kubernetes cluster. This is explained link:../getting-started#download-and-install[].
+You will also need the Kubernetes CLI (kubectl) to manage the resources on the Kubernetes cluster. If you don't have the Kubernetes CLI installed, please follow the instructions link:../getting-started#download-and-install[here] to do so.
 
 === Configure kops
 
 kops uses a public SSH key while creating a cluster. The location of this file defaults to `~/.ssh/id_rsa.pub`. Please generate an SSH key using `ssh-keygen` command.
 
-Alternatively, you can use the `--ssh-public-key` option to specify a custom location. More details about kops security can be found in the https://github.com/kubernetes/kops/blob/master/docs/security.md[kops docs].
+    $ ssh-keygen 
+    Generating public/private rsa key pair.
+    Enter file in which to save the key (~/.ssh/id_rsa):
+    Enter passphrase (empty for no passphrase): 
+    Enter same passphrase again: 
+    Your identification has been saved in ~/.ssh/id_rsa
+    Your public key has been saved in ~/.ssh/id_rsa.pub.
+    The key fingerprint is:
+    SHA256:bQXH2zAAcFVtpEwcOL5D1QZnXp3zkiC123456789
+    The key's randomart image is:
+    +---[RSA 2048]----+
+    |      ..oo=B**+ +|
+    |       . o+=B*=+.|
+    |        +..+*O+E=|
+    |       . =o=.o=oo|
+    |        S.*..  o |
+    |         oo      |
+    |           .     |
+    |                 |
+    |                 |
+    +----[SHA256]-----+
 
+Alternatively, you can use the `--ssh-public-key` option to specify a custom location. 
+More details about kops security can be found in the https://github.com/kubernetes/kops/blob/master/docs/security.md[documentation for kops].
 
-== IAM user permission
+== IAM user permissions
 
-Make sure the latest version of http://docs.aws.amazon.com/cli/latest/userguide/installing.html[AWS CLI]
-is installed. User permissions used in this workshop must have these http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html[IAM policies] attached.
+Make sure the latest version of the http://docs.aws.amazon.com/cli/latest/userguide/installing.html[AWS CLI]
+is installed. 
+
+   $ pip install --upgrade awscli
+
+The AWS user profile used in this workshop must have these http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html[IAM policies] attached.
 
     AmazonEC2FullAccess
     AmazonRoute53FullAccess
@@ -58,29 +86,29 @@ https://github.com/kubernetes/kops/blob/master/docs/aws.md#setup-iam-user. https
 
 == S3 bucket to store Kubernetes config
 
-kops needs a "`state store`" to store configuration information of the cluster.  For example, how many nodes in the cluster, the instance type of each node, and the Kubernetes version. The state is stored during the initial cluster creation. Any subsequent changes to the cluster are also persisted to this store. As of now, Amazon S3 is the only supported storage mechanism. Create an S3 bucket and pass that to the kops CLI during cluster creation.
+kops needs a "`state store`" to store the configuration information of the cluster.  For example: how many nodes in the cluster, the instance type of each node, and the Kubernetes version. The state is stored during the initial cluster creation. Any subsequent changes to the cluster are also persisted to this store. As of now, Amazon S3 is the only supported storage mechanism. Create an S3 bucket and pass that to the kops CLI during cluster creation.
 
 NOTE: The bucket name must be unique otherwise you will encounter an error on deployment. We will use an example bucket name of `example-state-store-` and add a randomly generated string to the end.
 
     # create variables for bucket, state store and cluster names
-    export S3_BUCKET=example-state-store-$(cat /dev/random | LC_ALL=C tr -dc "[:alpha:]" | tr '[:upper:]' '[:lower:]' | head -c 32)
-    export KOPS_STATE_STORE=s3://${S3_BUCKET}
+    $ export S3_BUCKET=example-state-store-$(cat /dev/random | LC_ALL=C tr -dc "[:alpha:]" | tr '[:upper:]' '[:lower:]' | head -c 32)
+    $ export KOPS_STATE_STORE=s3://${S3_BUCKET}
 
     # use aws cli to create bucket
-    aws s3 mb $KOPS_STATE_STORE
+    $ aws s3 mb $KOPS_STATE_STORE
 
     # enable versioning and export
-    aws s3api put-bucket-versioning \
+    $ aws s3api put-bucket-versioning \
       --bucket $S3_BUCKET \
       --versioning-configuration \
       Status=Enabled
 
-== Create cluster
+== Create the cluster
 
 The kops CLI can be used to create a highly available cluster, with multiple master nodes spread across multiple Availability Zones. Workers can be spread across multiple zones as well. Some of the tasks that happen behind the scene during cluster creation are:
 
 - Provisioning EC2 instances
-- Setting up AWS resources such as networks, Auto Scaling groups, IAM users, and security groups
+- Setting up AWS resources such as Networking, Auto Scaling Groups, IAM policies, and Security Groups
 - Installing Kubernetes
 
 When setting up a cluster you have two options on how the nodes in the cluster communicate:

--- a/cluster-install/readme.adoc
+++ b/cluster-install/readme.adoc
@@ -90,14 +90,14 @@ kops needs a "`state store`" to store the configuration information of the clust
 
 NOTE: The bucket name must be unique otherwise you will encounter an error on deployment. We will use an example bucket name of `example-state-store-` and add a randomly generated string to the end.
 
-    # create variables for bucket, state store and cluster names
+    # create variables for bucket, state store, and cluster names
     $ export S3_BUCKET=example-state-store-$(cat /dev/random | LC_ALL=C tr -dc "[:alpha:]" | tr '[:upper:]' '[:lower:]' | head -c 32)
     $ export KOPS_STATE_STORE=s3://${S3_BUCKET}
 
-    # use aws cli to create bucket
+    # use AWS CLI to create the bucket
     $ aws s3 mb $KOPS_STATE_STORE
 
-    # enable versioning and export
+    # enable versioning
     $ aws s3api put-bucket-versioning \
       --bucket $S3_BUCKET \
       --versioning-configuration \
@@ -108,21 +108,21 @@ NOTE: The bucket name must be unique otherwise you will encounter an error on de
 The kops CLI can be used to create a highly available cluster, with multiple master nodes spread across multiple Availability Zones. Workers can be spread across multiple zones as well. Some of the tasks that happen behind the scene during cluster creation are:
 
 - Provisioning EC2 instances
-- Setting up AWS resources such as Networking, Auto Scaling Groups, IAM policies, and Security Groups
+- Setting up AWS resources such as Networking, AutoScaling Groups, IAM policies, and Security Groups
 - Installing Kubernetes
 
 When setting up a cluster you have two options on how the nodes in the cluster communicate:
 
-. <<Create a gossip-based Kubernetes cluster, Using the gossip protocol>> - kops has experimental support for a gossip-based cluster. This does not require a domain, subdomain, or Route53 hosted zone to be registered. A gossip-based cluster is therefore easier and quicker to setup, and is the preferred method for creating a cluster for use with this workshop.
+. <<Create a gossip-based Kubernetes cluster, Using the gossip protocol>> - kops has recent support for a gossip-based cluster. This does not require a domain, subdomain, or Route53 hosted zone to be registered. A gossip-based cluster is therefore easier and quicker to setup, and is the preferred method for creating a cluster for use with this workshop.
 . <<Create a DNS-based Kubernetes cluster, Using DNS>> - Creating a Kubernetes cluster that uses DNS for node discovery requires your own domain (or subdomain) and setting up Route 53 hosted zones. This allows the various Kubernetes components to use DNS resolutions find and communicate with each other, and for kubectl to be able to talk directly with the master node(s).
 
-Instructions for creating a gossip-baed cluster are provided below, however, the examples in the workshop should work with either option. Instructions for creating a DNS-based cluster are provided as an addendum at the bottom of this page.
+Instructions for creating a gossip-based cluster are provided below, however, the examples in the workshop should work with either option. Instructions for creating a DNS-based cluster are provided as an appendix at the bottom of this page.
 
 NOTE: If you're using London region (`eu-west-2`) you need to add `--cloud aws` as kops is not identifying that `eu-west-2` indicates AWS. Further info https://github.com/kubernetes/kops/issues/1267
 
 === Create a gossip-based Kubernetes cluster
 
-kops supports for a gossip-based cluster, which uses Weave Mesh behind the scenes. This makes the process of creating a Kubernetes cluster using kops DNS-free, and therefore much simpler. This also means a top-level domain or a subdomain is no longer required to create the cluster. To create a cluster using the gossip protocol, indicate this to by using a cluster name with a suffix of `.k8s.local`. In the following steps, we will use example.cluster.k8s.local as a sample gossip cluster name. You may choose a different name as long as it ends with `.k8s.local`.
+kops supports creating a gossip-based cluster, which uses Weave Mesh behind the scenes. This makes the process of creating a Kubernetes cluster using kops DNS-free, and therefore much simpler. This also means a top-level domain or a subdomain is no longer required to create the cluster. To create a cluster using the gossip protocol, indicate this to by using a cluster name with a suffix of `.k8s.local`. In the following steps, we will use example.cluster.k8s.local as a sample gossip cluster name. You may choose a different name as long as it ends with `.k8s.local`.
 
 This is a fairly recent feature, so we recommend you continue to use DNS for production clusters. Information on setting up a DNS-based cluster can be found at the bottom of this page in the Appendix. However, setting up a gossip-based cluster allows you to get started quickly.
 
@@ -134,22 +134,22 @@ By default, `create cluster` command creates a single master node and two worker
 
 Create a Kubernetes cluster using the following command. This will create a cluster with a single master, multi-node and multi-az configuration:
 
-    kops create cluster \
+    $ kops create cluster \
       --name example.cluster.k8s.local \
       --zones $AWS_AVAILABILITY_ZONES \
       --yes
 
 You can find the command for creating the `AWS_AVAILABILITY_ZONES` environment variable at link:../prereqs.adoc#aws-availability-zones[].
 
-The `create cluster` command only creates and stores the cluster config in the S3 bucket. Adding `--yes` option ensures that the cluster is immediately created as well.
+The `create cluster` command only creates and stores the cluster config in the S3 bucket. Adding the `--yes` flag ensures that the cluster is immediately created as well.
 
-Alternatively, you may not specify the `--yes` option as part of the `kops create cluster` command. Then you can use `kops edit cluster example.cluster.k8s.local` command to view the current cluster state and make changes. The cluster creation, in that case, is started with the following command:
+Alternatively, you may not specify the `--yes` flag as part of the `kops create cluster` command. Then you can use `kops edit cluster example.cluster.k8s.local` command to view the current cluster state and make changes. The cluster creation, in that case, is started with the following command:
 
-    kops update cluster example.cluster.k8s.local --yes
+    $ kops update cluster example.cluster.k8s.local --yes
 
-Once the `kops create cluster` command is issued, it provisions the EC2 instances, setup Auto Scaling Groups, IAM users, security groups, and install Kubernetes on each node, configures master and worker nodes. This process can take a few minutes based upon the number of master and worker nodes.
+Once the `kops create cluster` command is issued, it provisions the EC2 instances, sets up Auto Scaling Groups, IAM users, Security Groups, installs Kubernetes on each node, then configures the master and worker nodes. This process can take some time based upon the number of master and worker nodes.
 
-Wait for 10-15 minutes and then the cluster can be validated as shown:
+Wait for 10-15 minutes and then validate the cluster as shown:
 
 ```
 $ kops validate cluster
@@ -194,7 +194,7 @@ Create a cluster with multi-master, multi-node and multi-az configuration. We ca
 
 A multi-master cluster can be created by using the `--master-count` option and specifying the number of master nodes. An odd value is recommended. By default, the master nodes are spread across the AZs specified using the `--zones` option. Alternatively, `--master-zones` option can be used to explicitly specify the zones for the master nodes.
 
-`--zones` option is also used to distribute the worker nodes. The number of workers is specified using the `--node-count` option.
+The `--zones` option is also used to distribute the worker nodes. The number of workers is specified using the `--node-count` option.
 
 As mentioned above, wait for 10-15 minutes for the cluster to be created. Validate the cluster:
 
@@ -227,9 +227,9 @@ Your cluster example.cluster.k8s.local is ready
 
 Note that all masters are spread across different AZs.
 
-Your output may differ from the one shown here based up on the type of cluster you created.
+Your output may differ slightly from the one shown here based up on the type of cluster you created.
 
-=== Create a Kubernetes cluster in a private VPC
+=== (Optional) Create a Kubernetes cluster in a private VPC
 
 kops can create a private Kubernetes cluster, where the master and worker nodes are launched in private subnets in a VPC. This is possible with both gossip-based and DNS-based clusters. This reduces the attack surface on your instances by protecting them behind security groups inside private subnets. The services hosted in the cluster can still be exposed via internet-facing ELBs if required. It is necessary to run an overlay network in the Kubernetes cluster when using a private topology. We have used https://www.projectcalico.org/[Calico] below, though other options such as `kopeio-vxlan`, `weave` and `cni` are available.
 

--- a/cluster-install/readme.adoc
+++ b/cluster-install/readme.adoc
@@ -9,21 +9,21 @@ kops is available on Mac OSX, Linux, or the Windows 10 Linux Subsystem.
 
 == Install kops
 
-There is no need to download a Kubernetes binary distribution for creating a cluster using kops. However, you do need to download the kops CLI. It then takes care of downloading the right Kubernetes binary in the cloud, and provisions the cluster.
+There is no need to download a Kubernetes binary distribution for creating a cluster using kops. However, you do need to download the kops CLI. It takes care of downloading the right Kubernetes binary in the cloud, and then provisions and manages the cluster.
 
 ==== macOS
 
-    brew update && brew install kops
+    $ brew update && brew install kops
 
 If kops is already installed, then it can be upgraded to the latest version using the following command:
 
-    brew upgrade kops
+    $ brew upgrade kops
 
 ==== Linux / Windows 10 Linux Subsystem
 
-    wget https://github.com/kubernetes/kops/releases/download/1.7.1/kops-linux-amd64
-    sudo chmod +x kops-linux-amd64
-    sudo mv kops-linux-amd64 /usr/local/bin/kops
+    $ wget https://github.com/kubernetes/kops/releases/download/1.7.1/kops-linux-amd64
+    $ sudo chmod +x kops-linux-amd64
+    $ sudo mv kops-linux-amd64 /usr/local/bin/kops
 
 
 Complete installation instructions are available https://github.com/kubernetes/kops#installing[here].
@@ -80,6 +80,8 @@ The AWS user profile used in this workshop must have these http://docs.aws.amazo
     AmazonS3FullAccess
     IAMFullAccess
     AmazonVPCFullAccess
+
+If you are using the AWS user and credentials created as part of the link:prereqs.adoc[Prerequisites], then you should already have these permissions.
 
 Please review these links for additional info on IAM permissions:
 https://github.com/kubernetes/kops/blob/master/docs/aws.md#setup-iam-user. https://github.com/kubernetes/kops/blob/master/docs/iam_roles.md
@@ -173,8 +175,8 @@ Your cluster example.cluster.k8s.local is ready
 
 Sometimes the cluster creation does not work and the validation fails. This happens when only worker nodes are created and master node is not provisioned. This is filed as https://github.com/kubernetes/kops/issues/3751[kops/#3751]. As a workaround, specifying the exact number of master node(s) and worker node(s) will create the cluster successfully. The exact command for that is:
 
-    kops delete cluster --name example.cluster.k8s.local --yes
-    kops create cluster \
+    $ kops delete cluster --name example.cluster.k8s.local --yes
+    $ kops create cluster \
       --name example.cluster.k8s.local \
       --zones $AWS_AVAILABILITY_ZONES \
       --master-count=1 \
@@ -185,7 +187,7 @@ Sometimes the cluster creation does not work and the validation fails. This happ
 
 Create a cluster with multi-master, multi-node and multi-az configuration. We can create and build the cluster in one step by passing the `--yes` flag.
 
-    kops create cluster \
+    $ kops create cluster \
       --name example.cluster.k8s.local \
       --master-count 3 \
       --node-count 5 \
@@ -235,7 +237,7 @@ kops can create a private Kubernetes cluster, where the master and worker nodes 
 
 Create a gossip-based private cluster with master and worker nodes in private subnets:
 
-    kops create cluster \
+    $ kops create cluster \
       --networking calico \
       --topology private \
       --name example.cluster.k8s.local \
@@ -436,7 +438,7 @@ The `create cluster` command only creates and stores the cluster config in the S
 
 Alternatively, you may not specify the `--yes` option as part of the `kops create cluster` command. Then you can use `kops edit cluster example.cluster.com` command to view the current cluster state and make changes. The cluster creation, in that case, is started with the following command:
 
-    kops update cluster example.cluster.com --yes
+    $ kops update cluster example.cluster.com --yes
 
 Once the `kops create cluster` command is issued, it provisions the EC2 instances, setup Auto Scaling Groups, IAM users, security groups, and install Kubernetes on each node, configures master and worker nodes. This process can take a few minutes based upon the number of master and worker nodes.
 

--- a/cluster-install/readme.adoc
+++ b/cluster-install/readme.adoc
@@ -183,8 +183,7 @@ Sometimes the cluster creation does not work and the validation fails. This happ
 
 ==== Multi-master, multi-node, multi-az gossip-based cluster
 
-Create a cluster with multi-master, multi-node and multi-az configuration. We can create and build the cluster in
-one step by passing the `--yes` flag.
+Create a cluster with multi-master, multi-node and multi-az configuration. We can create and build the cluster in one step by passing the `--yes` flag.
 
     kops create cluster \
       --name example.cluster.k8s.local \
@@ -243,7 +242,7 @@ Create a gossip-based private cluster with master and worker nodes in private su
       --zones $AWS_AVAILABILITY_ZONES \
       --yes
 
-Once the `kops create cluster` command is issued, it provisions the EC2 instances, setup Auto Scaling Groups, IAM users, security groups, and install Kubernetes on each node, configures master and worker nodes. This process can take a few minutes based upon the number of master and worker nodes.
+Once the `kops create cluster` command is issued, it provisions the EC2 instances, sets up AutoScaling Groups, IAM users, Security Groups, installs Kubernetes on each node, then configures the master and worker nodes. This process can take some time based upon the number of master and worker nodes.
 
 Wait for 10-15 minutes and then the cluster can be validated as shown:
 
@@ -312,7 +311,7 @@ Specific API versions can be turned on or off by passing `--runtime-config=api/<
 
 For a cluster created using kops, this can be done by editing the cluster configuration using the command shown:
 
-  kops edit cluster --name example.cluster.k8s.local
+    $ kops edit cluster --name example.cluster.k8s.local
 
 This will open up the cluster configuration in a text editor. Update the `spec` attribute such that it looks like as shown:
 
@@ -383,32 +382,35 @@ The output clearly shows that `--runtime-config=batch/v2alpha1=true` is passed a
 == Instance groups with kops
 
 An instance group is a kops concept that defines a grouping of similar machines. In AWS, an instance group maps to an
-AutoScalingGroup (ASG). Instructions on how to create instance groups can be found link:instance-groups/readme.adoc[here].
+AutoScaling Group (ASG). Instructions on how to create instance groups can be found link:instance-groups/readme.adoc[here].
 
 == Delete cluster
 
 Any cluster can be deleted as shown:
 
-    kops delete cluster \
+    $ kops delete cluster \
       <cluster-name> \
       --yes
 
 `<cluster-name>` is the name of the cluster. For example, our `example.cluster.k8s.local` cluster can be deleted as:
 
-    kops delete cluster \
+    $ kops delete cluster \
       example.cluster.k8s.local \
       --yes
+
+If you leave off the `--yes` flag, you will get a listing of all the resources kops will delete.  To confirm deletion, run the command again appending `--yes`.
 
 If you created a private VPC, then an additional cleanup of resources is required as shown below:
 
     # Find Route53 hosted zone ID from the console or via CLI and delete hosted zone
-    aws route53 delete-hosted-zone --id Z1234567890ABC
+    $ aws route53 delete-hosted-zone --id Z1234567890ABC
+
     # Delete VPC if you created earlier
-    aws ec2 detach-internet-gateway --internet $IGW --vpc $VPCID
+    $ aws ec2 detach-internet-gateway --internet $IGW --vpc $VPCID
     aws ec2 delete-internet-gateway --internet-gateway-id $IGW
     aws ec2 delete-vpc --vpc-id $VPCID
 
-=== Appendix: Create a DNS-based Kubernetes cluster
+== Appendix: Create a DNS-based Kubernetes cluster
 
 To create a DNS-based Kubernetes cluster you'll need a top-level domain or subdomain that meets one of the following scenarios:
 
@@ -425,7 +427,7 @@ By default, `create cluster` command creates a single master node and two worker
 
 Create a Kubernetes cluster using the following command. For the purposes of this demonstration, we will use a cluster name of example.cluster.com as our registered DNS. This will create a cluster with a single master, multi-node and multi-az configuration:
 
-    kops create cluster \
+    $ kops create cluster \
       --name example.cluster.com \
       --zones $AWS_AVAILABILITY_ZONES \
       --yes
@@ -470,12 +472,12 @@ It shows that Kubectl CLI version is 1.8.1 and the server version is 1.7.4.
 
 Check the list of Availability Zones that exist for your region using the following command:
 
-    aws --region <region> ec2 describe-availability-zones
+    $ aws --region <region> ec2 describe-availability-zones
 
 Create a cluster with multi-master, multi-node and multi-az configuration. We can create and build the cluster in
 one step by passing the `--yes` flag.
 
-    kops create cluster \
+    $ kops create cluster \
       --name example.cluster.com \
       --master-count 3 \
       --node-count 5 \

--- a/cluster-install/readme.adoc
+++ b/cluster-install/readme.adoc
@@ -84,10 +84,10 @@ The kops CLI can be used to create a highly available cluster, with multiple mas
 
 When setting up a cluster you have two options on how the nodes in the cluster communicate:
 
-. <<Create a DNS-based Kubernetes cluster, Using DNS>> - Creating a Kubernetes cluster that uses DNS for node discovery requires your own domain (or subdomain) and setting up Route 53 hosted zones. This allows the various Kubernetes components to find and communicate with each other. This is also necessary for kubectl to be able to talk directly with the master.
-. <<Create a gossip-based Kubernetes cluster, Using the gossip protocol>> - kops has experimental support for a gossip-based cluster. This does not require a  domain, subdomain, or Route53 hosted zone to be registered. A gossip-based cluster is therefore easier and quicker to setup.
+. <<Create a gossip-based Kubernetes cluster, Using the gossip protocol>> - kops has experimental support for a gossip-based cluster. This does not require a domain, subdomain, or Route53 hosted zone to be registered. A gossip-based cluster is therefore easier and quicker to setup, and is the preferred method for creating a cluster for use with this workshop.
+. <<Create a DNS-based Kubernetes cluster, Using DNS>> - Creating a Kubernetes cluster that uses DNS for node discovery requires your own domain (or subdomain) and setting up Route 53 hosted zones. This allows the various Kubernetes components to use DNS resolutions find and communicate with each other, and for kubectl to be able to talk directly with the master node(s).
 
-You'll need to choose one of the two options. Instructions for both options are provided below, and the examples in the workshop should work with either option. Creating a gossip-based cluster requires less setup and will be used in this workshop, unless otherwise specified.
+Instructions for creating a gossip-baed cluster are provided below, however, the examples in the workshop should work with either option. Instructions for creating a DNS-based cluster are provided as an addendum at the bottom of this page.
 
 NOTE: If you're using London region (`eu-west-2`) you need to add `--cloud aws` as kops is not identifying that `eu-west-2` indicates AWS. Further info https://github.com/kubernetes/kops/issues/1267
 
@@ -238,118 +238,9 @@ ip-172-20-93-220.eu-central-1.compute.internal  node    True
 Your cluster example.cluster.k8s.local is ready
 ```
 
-It is also possible to create a DNS-based cluster where the master and worker nodes are in private subnets. A `--dns-zone` argument is required to specify the domain. If `--dns private` is also specified, a Route53 private hosted zone is created for routing the traffic for the domain within one or more VPCs. The Kubernetes API can therefore only be accessed from within the VPC. This is a current issue with kops (see https://github.com/kubernetes/kops/issues/2032). A possible workaround is to mirror the private Route53 hosted zone with a public hosted zone that exposes only the API server ELB endpoint. This workaround is discussed http://kubecloud.io/setup-ha-k8s-kops/[here].
+It is also possible to create a DNS-based cluster (see Appendix: Create a DNS-based Kubernetes cluster below) where the master and worker nodes are in private subnets. A `--dns-zone` argument is required to specify the domain. If `--dns private` is also specified, a Route53 private hosted zone is created for routing the traffic for the domain within one or more VPCs. The Kubernetes API can therefore only be accessed from within the VPC. This is a current issue with kops (see https://github.com/kubernetes/kops/issues/2032). A possible workaround is to mirror the private Route53 hosted zone with a public hosted zone that exposes only the API server ELB endpoint. This workaround is discussed http://kubecloud.io/setup-ha-k8s-kops/[here].
 
 Although most of the exercises in this workshop should work on a cluster with a private VPC, some commands won't, specifically those that use a proxy to access internally hosted services.
-
-=== Create a DNS-based Kubernetes cluster
-
-To create a DNS-based Kubernetes cluster you'll need a top-level domain or subdomain that meets one of the following scenarios:
-
-. Domain purchased/hosted via AWS
-. A subdomain under a domain purchased/hosted via AWS
-. Setting up Route53 for a domain purchased with another registrar, transfering the domain to Route53
-. Subdomain for clusters in Route53, leaving the domain at another registrar
-
-Then you need to follow the instructions in https://github.com/kubernetes/kops/blob/master/docs/aws.md#configure-dns[configure DNS]. Typically, the first and the last bullets are common scenarios.
-
-==== Default DNS-based cluster
-
-By default, `create cluster` command creates a single master node and two worker nodes in the specified zones.
-
-Create a Kubernetes cluster using the following command. For the purposes of this demonstration, we will use a cluster name of example.cluster.com as our registered DNS. This will create a cluster with a single master, multi-node and multi-az configuration:
-
-    kops create cluster \
-      --name example.cluster.com \
-      --zones $AWS_AVAILABILITY_ZONES \
-      --yes
-
-The `create cluster` command only creates and stores the cluster config in the S3 bucket. Adding `--yes` option ensures that the cluster is immediately created as well.
-
-Alternatively, you may not specify the `--yes` option as part of the `kops create cluster` command. Then you can use `kops edit cluster example.cluster.com` command to view the current cluster state and make changes. The cluster creation, in that case, is started with the following command:
-
-    kops update cluster example.cluster.com --yes
-
-Once the `kops create cluster` command is issued, it provisions the EC2 instances, setup Auto Scaling Groups, IAM users, security groups, and install Kubernetes on each node, configures master and worker nodes. This process can take a few minutes based upon the number of master and worker nodes.
-
-Wait for 10-15 minutes and then the cluster can be validated as shown:
-
-```
-$ kops validate cluster --name=example.cluster.com
-Validating cluster example.cluster.com
-
-INSTANCE GROUPS
-NAME      ROLE  MACHINETYPE MIN MAX SUBNETS
-master-eu-central-1a Master  m3.medium 1 1 eu-central-1a
-nodes     Node  t2.medium 2 2 eu-central-1a,eu-central-1b
-
-NODE STATUS
-NAME        ROLE  READY
-ip-172-20-51-232.ec2.internal node  True
-ip-172-20-60-192.ec2.internal master  True
-ip-172-20-91-39.ec2.internal  node  True
-
-Your cluster example.cluster.com is ready
-```
-
-Verify the client and server version:
-
-  $ kubectl version
-  Client Version: version.Info{Major:"1", Minor:"8", GitVersion:"v1.8.1", GitCommit:"f38e43b221d08850172a9a4ea785a86a3ffa3b3a", GitTreeState:"clean", BuildDate:"2017-10-12T00:45:05Z", GoVersion:"go1.9.1", Compiler:"gc", Platform:"darwin/amd64"}
-  Server Version: version.Info{Major:"1", Minor:"7", GitVersion:"v1.7.4", GitCommit:"793658f2d7ca7f064d2bdf606519f9fe1229c381", GitTreeState:"clean", BuildDate:"2017-08-17T08:30:51Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"linux/amd64"}
-
-It shows that Kubectl CLI version is 1.8.1 and the server version is 1.7.4.
-
-==== Multi-master, multi-node, multi-az DNS-based cluster
-
-Check the list of Availability Zones that exist for your region using the following command:
-
-    aws --region <region> ec2 describe-availability-zones
-
-Create a cluster with multi-master, multi-node and multi-az configuration. We can create and build the cluster in
-one step by passing the `--yes` flag.
-
-    kops create cluster \
-      --name example.cluster.com \
-      --master-count 3 \
-      --node-count 5 \
-      --zones $AWS_AVAILABILITY_ZONES \
-      --yes
-
-A multi-master cluster can be created by using the `--master-count` option and specifying the number of master nodes. An odd value is recommended. By default, the master nodes are spread across the AZs specified using the `--zones` option. Alternatively, `--master-zones` option can be used to explicitly specify the zones for the master nodes.
-
-`--zones` option is also used to distribute the worker nodes. The number of workers is specified using the `--node-count` option.
-
-As mentioned above, wait for 10-15 minutes for the cluster to be created. Validate the cluster:
-
-```
-$ kops validate cluster --name=example.cluster.com
-Validating cluster example.cluster.com
-
-INSTANCE GROUPS
-NAME      ROLE  MACHINETYPE MIN MAX SUBNETS
-master-eu-central-1a Master  m3.medium 1 1 eu-central-1a
-master-eu-central-1b Master  m3.medium 1 1 eu-central-1b
-master-eu-central-1c Master  c4.large  1 1 eu-central-1c
-nodes     Node  t2.medium 5 5 eu-central-1a,eu-central-1b,eu-central-1c
-
-NODE STATUS
-NAME        ROLE  READY
-ip-172-20-103-30.ec2.internal master  True
-ip-172-20-105-16.ec2.internal node  True
-ip-172-20-127-147.ec2.internal  node  True
-ip-172-20-35-38.ec2.internal  node  True
-ip-172-20-47-199.ec2.internal node  True
-ip-172-20-61-207.ec2.internal master  True
-ip-172-20-75-78.ec2.internal  master  True
-ip-172-20-94-216.ec2.internal node  True
-
-Your cluster example.cluster.com is ready
-```
-
-Note that all masters are spread across different AZs.
-
-Your output may differ from the one shown here based up on the type of cluster you created.
 
 == Kubernetes cluster context
 
@@ -357,7 +248,7 @@ You may create multiple Kubernetes clusters. The configuration for each cluster 
 
 This allows you to deploy your applications to different environments by just changing the context. For example, here is a typical flow for application development:
 
-. Build your application using minikube
+. Build your application using minikube (See Set up Local Development Environment for more information)
 . Change the context to a test cluster created on AWS
 . Use the same command to deploy to test environment
 . Once satisfied, change the context again to a production cluster on AWS
@@ -487,3 +378,112 @@ If you created a private VPC, then an additional cleanup of resources is require
     aws ec2 detach-internet-gateway --internet $IGW --vpc $VPCID
     aws ec2 delete-internet-gateway --internet-gateway-id $IGW
     aws ec2 delete-vpc --vpc-id $VPCID
+
+=== Appendix: Create a DNS-based Kubernetes cluster
+
+To create a DNS-based Kubernetes cluster you'll need a top-level domain or subdomain that meets one of the following scenarios:
+
+. Domain purchased/hosted via AWS
+. A subdomain under a domain purchased/hosted via AWS
+. Setting up Route53 for a domain purchased with another registrar, transfering the domain to Route53
+. Subdomain for clusters in Route53, leaving the domain at another registrar
+
+Then you need to follow the instructions in https://github.com/kubernetes/kops/blob/master/docs/aws.md#configure-dns[configure DNS]. Typically, the first and the last bullets are common scenarios.
+
+==== Default DNS-based cluster
+
+By default, `create cluster` command creates a single master node and two worker nodes in the specified zones.
+
+Create a Kubernetes cluster using the following command. For the purposes of this demonstration, we will use a cluster name of example.cluster.com as our registered DNS. This will create a cluster with a single master, multi-node and multi-az configuration:
+
+    kops create cluster \
+      --name example.cluster.com \
+      --zones $AWS_AVAILABILITY_ZONES \
+      --yes
+
+The `create cluster` command only creates and stores the cluster config in the S3 bucket. Adding `--yes` option ensures that the cluster is immediately created as well.
+
+Alternatively, you may not specify the `--yes` option as part of the `kops create cluster` command. Then you can use `kops edit cluster example.cluster.com` command to view the current cluster state and make changes. The cluster creation, in that case, is started with the following command:
+
+    kops update cluster example.cluster.com --yes
+
+Once the `kops create cluster` command is issued, it provisions the EC2 instances, setup Auto Scaling Groups, IAM users, security groups, and install Kubernetes on each node, configures master and worker nodes. This process can take a few minutes based upon the number of master and worker nodes.
+
+Wait for 10-15 minutes and then the cluster can be validated as shown:
+
+```
+$ kops validate cluster --name=example.cluster.com
+Validating cluster example.cluster.com
+
+INSTANCE GROUPS
+NAME      ROLE  MACHINETYPE MIN MAX SUBNETS
+master-eu-central-1a Master  m3.medium 1 1 eu-central-1a
+nodes     Node  t2.medium 2 2 eu-central-1a,eu-central-1b
+
+NODE STATUS
+NAME        ROLE  READY
+ip-172-20-51-232.ec2.internal node  True
+ip-172-20-60-192.ec2.internal master  True
+ip-172-20-91-39.ec2.internal  node  True
+
+Your cluster example.cluster.com is ready
+```
+
+Verify the client and server version:
+
+  $ kubectl version
+  Client Version: version.Info{Major:"1", Minor:"8", GitVersion:"v1.8.1", GitCommit:"f38e43b221d08850172a9a4ea785a86a3ffa3b3a", GitTreeState:"clean", BuildDate:"2017-10-12T00:45:05Z", GoVersion:"go1.9.1", Compiler:"gc", Platform:"darwin/amd64"}
+  Server Version: version.Info{Major:"1", Minor:"7", GitVersion:"v1.7.4", GitCommit:"793658f2d7ca7f064d2bdf606519f9fe1229c381", GitTreeState:"clean", BuildDate:"2017-08-17T08:30:51Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"linux/amd64"}
+
+It shows that Kubectl CLI version is 1.8.1 and the server version is 1.7.4.
+
+==== Multi-master, multi-node, multi-az DNS-based cluster
+
+Check the list of Availability Zones that exist for your region using the following command:
+
+    aws --region <region> ec2 describe-availability-zones
+
+Create a cluster with multi-master, multi-node and multi-az configuration. We can create and build the cluster in
+one step by passing the `--yes` flag.
+
+    kops create cluster \
+      --name example.cluster.com \
+      --master-count 3 \
+      --node-count 5 \
+      --zones $AWS_AVAILABILITY_ZONES \
+      --yes
+
+A multi-master cluster can be created by using the `--master-count` option and specifying the number of master nodes. An odd value is recommended. By default, the master nodes are spread across the AZs specified using the `--zones` option. Alternatively, `--master-zones` option can be used to explicitly specify the zones for the master nodes.
+
+`--zones` option is also used to distribute the worker nodes. The number of workers is specified using the `--node-count` option.
+
+As mentioned above, wait for 10-15 minutes for the cluster to be created. Validate the cluster:
+
+```
+$ kops validate cluster --name=example.cluster.com
+Validating cluster example.cluster.com
+
+INSTANCE GROUPS
+NAME      ROLE  MACHINETYPE MIN MAX SUBNETS
+master-eu-central-1a Master  m3.medium 1 1 eu-central-1a
+master-eu-central-1b Master  m3.medium 1 1 eu-central-1b
+master-eu-central-1c Master  c4.large  1 1 eu-central-1c
+nodes     Node  t2.medium 5 5 eu-central-1a,eu-central-1b,eu-central-1c
+
+NODE STATUS
+NAME        ROLE  READY
+ip-172-20-103-30.ec2.internal master  True
+ip-172-20-105-16.ec2.internal node  True
+ip-172-20-127-147.ec2.internal  node  True
+ip-172-20-35-38.ec2.internal  node  True
+ip-172-20-47-199.ec2.internal node  True
+ip-172-20-61-207.ec2.internal master  True
+ip-172-20-75-78.ec2.internal  master  True
+ip-172-20-94-216.ec2.internal node  True
+
+Your cluster example.cluster.com is ready
+```
+
+Note that all masters are spread across different AZs.
+
+Your output may differ from the one shown here based up on the type of cluster you created.

--- a/getting-started/readme.adoc
+++ b/getting-started/readme.adoc
@@ -170,6 +170,7 @@ Expose the deployment creates what Kubernetes calls a service. You can see the p
     $ kubectl get service
     NAME         TYPE           CLUSTER-IP      EXTERNAL-IP        PORT(S)        AGE
     kubernetes   ClusterIP      100.64.0.1      <none>             443/TCP        2d
+    web          NodePort       100.67.45.110   <none>             80:32400/TCP   32s
 
 We will learn more about Services and Deployments later in the workshop.    
 

--- a/getting-started/readme.adoc
+++ b/getting-started/readme.adoc
@@ -4,15 +4,13 @@
 :imagesdir: ../images
 :toc:
 
-Before starting this section, please have created  a highly available cluster on AWS using https://github.com/kubernetes/kops[kops], as explained here: link:../cluster-install[cluster install] section.
+Before starting this section, please have created a cluster on AWS with https://github.com/kubernetes/kops[kops], as explained in the link:../cluster-install[Create a Kubernetes cluster using kops] section.
 
 == Kubernetes basic commands
 
 Now that we have a cluster up and running we can start issuing some basic commands and deploy some simple resources.
 
-In this part we will familiarize ourselves with the `kubectl` CLI tool and basic Kubernetes commands. We will first deploy a basic NGiNX pod and execute some commands to help developers gain comfort with the Kubernetes environment from an end-user perspective. This helps get developers up and running taking advantage of the Kubernetes application deployment capabilities without having to worry about the infrastructure related complexities.
-
-NOTE: The kubectl commands below will be routed via your virtualbox network interface. If you are using a VPN or have a local firewall, this may prevent kubectl from contacting the minikube endpoint. Stopping the VPN or adding a firewall rule may resolve this.
+In this part we will familiarize ourselves with the `kubectl` CLI tool and basic Kubernetes commands. We will first deploy a basic NGiNX pod and execute some commands to help you gain comfort with the Kubernetes environment from an end-user perspective. This helps get developers up and running - taking advantage of the Kubernetes application deployment capabilities - without having to worry about the infrastructure related complexities.
 
 === Display nodes
 

--- a/getting-started/readme.adoc
+++ b/getting-started/readme.adoc
@@ -201,7 +201,7 @@ Replace the `Values` value with the nodeName retreived earlier.
         ]
     ]    
 
-Next, we add an ingress rule to the security group opening up the port on the node to anyone - `0.0.0.0/0`. This is purely for demonstration purposes in this workshop and is not a best practice. Most services will be exposed behind a load balancer, which we cover in the next section.  For the command below, replace the `--port` flag value with the nodePort retreived above.
+Next, we add an ingress rule to the security group opening up the port on the node to anyone - `0.0.0.0/0`. This is purely for demonstration purposes in this workshop and is not a best practice. Most services will be exposed behind a load balancer, which we cover in the next section.  For the command below, replace the `--group-id` parameter with the GroupId you just retrieved, and the `--port` parameter value with the nodePort retreived above.
 
     $ aws ec2 authorize-security-group-ingress --group-id sg-c0285fa8 --protocol tcp --port 32400 --cidr 0.0.0.0/0
 

--- a/getting-started/readme.adoc
+++ b/getting-started/readme.adoc
@@ -160,11 +160,11 @@ This command will open a TTY to a shell in your pod:
 
 This opens a Bash shell and allows you to look around the filesystem of the container.
 
-=== Expose the deployment as a Service
+=== Expose the deployment as a service via NodePort
 
 By default, all Kubernetes resources are only accessible within the cluster. This command will create a loadBalancer and allow the the NGiNX deployment to be accessible from the Internet:
 
-    $ kubectl expose deployment nginx --type=LoadBalancer --port=80 --target-port=80 --name=web
+    $ kubectl expose deployment nginx --type=NodePort --port=80 --target-port=80 --name=web
     service "web" exposed
 
 This will expose the deployment as a Service. You can see the published service:
@@ -172,19 +172,123 @@ This will expose the deployment as a Service. You can see the published service:
     $ kubectl get service
     NAME         TYPE           CLUSTER-IP      EXTERNAL-IP        PORT(S)        AGE
     kubernetes   ClusterIP      100.64.0.1      <none>             443/TCP        2d
-    web          LoadBalancer   100.69.223.33   a904073d0d6fe...   80:31259/TCP   32s
 
 We will learn more about Services and Deployments later in the workshop.    
 
-=== View Service webpage
+== View the NGiNX deployment via the NodePort
 
-We can find the hostname of the LoadBalancer created when we exposed the nginx deployment as service.
+First, we find the hostname of the node on which the nginx Pod is running: 
+
+    $ kubectl get pods -l="run=nginx" 
+    NAME                     READY     STATUS    RESTARTS   AGE
+    nginx-4217019353-pmkzb   1/1       Running   0          16m
+
+    $ kubectl get pod nginx-4217019353-pmkzb -o=jsonpath={.spec.nodeName}
+    ip-172-20-87-91.us-east-2.compute.internal
+
 The `-o` flag allows us to choose a different output format, and choosing the `jsonpath` output format allows us to filter the resultant JSON down to the exact value we need. 
 
-    $ kubectl get service web -o jsonpath={.status.loadBalancer.ingress..hostname}
-    a904073d0d6fe11e7af8f06c4465216f-766639162.us-east-2.elb.amazonaws.com
+Next we need the dynamic port the service opened for us on the Node running the NGiNX pod.
 
-Placing that hostname into a browser should show the default NGiNX homepage.
+    $ kubectl get service web -o jsonpath={.spec.ports..nodePort}
+    32400
+
+Next, we need to open the port on the node itself to receive traffic that port. We do this by finding the security group to which the node belongs.
+
+   $ aws ec2 describe-instances --filters "Name=private-dns-name,Values=ip-172-20-87-91.us-east-2.compute.internal" --query 'Reservations[*].Instances[*].SecurityGroups[*].GroupId'
+    [
+        [
+            "sg-c0285fa8"
+        ]
+    ]    
+
+    $ aws ec2 authorize-security-group-ingress --group-id sg-c0285fa8 --protocol tcp --port 32400 --cidr 0.0.0.0/0
+
+    $ aws ec2 describe-instances --filters "Name=private-dns-name,Values=ip-172-20-87-91.us-east-2.compute.internal" --query 'Reservations[*].Instances[*].NetworkInterfaces[*].PrivateIpAddresses[*].Association.PublicDnsName'
+    [
+        [
+            [
+                "ec2-18-216-5-70.us-east-2.compute.amazonaws.com"
+            ]
+        ]
+    ]
+
+You should now be able to go to point a browser or use `curl` to go to the combined site and see the default NGiNX homepage:
+
+    $ curl http://ec2-18-216-5-70.us-east-2.compute.amazonaws.com:32400 
+    <!DOCTYPE html>
+    <html>
+    <head>
+    <title>Welcome to nginx!</title>
+    <style>
+        body {
+            width: 35em;
+            margin: 0 auto;
+            font-family: Tahoma, Verdana, Arial, sans-serif;
+        }
+    </style>
+    </head>
+    <body>
+    <h1>Welcome to nginx!</h1>
+    <p>If you see this page, the nginx web server is successfully installed and
+    working. Further configuration is required.</p>
+
+    <p>For online documentation and support please refer to
+    <a href="http://nginx.org/">nginx.org</a>.<br/>
+    Commercial support is available at
+    <a href="http://nginx.com/">nginx.com</a>.</p>
+
+    <p><em>Thank you for using nginx.</em></p> 
+    
+=== Expose a deployment as a service via a load balancer
+
+Delete the existing service and deployment:
+
+    $ kubectl delete service/web deployment/nginx
+    service "web" deleted
+    deployment "nginx" deleted
+
+Create a new NGiNX deployment, this time with 2 pods.
+
+    $ kubectl run nginx --image=nginx --replicas=2
+    deployment "nginx" created
+
+Next we expose the deployment as a service, this time with a Load Balancer instead of a Node Port:
+
+    $ kubectl expose deployment nginx --type=LoadBalancer --port=80 --target-port=80 --name=web
+    service "web" exposed
+
+We can see the status of the load balancer creation by describing the service:
+```
+$ kubectl describe service web
+Name:                     web
+Namespace:                default
+Labels:                   run=nginx
+Annotations:              <none>
+Selector:                 run=nginx
+Type:                     LoadBalancer
+IP:                       100.69.50.175
+LoadBalancer Ingress:     ae70e9781d70e11e7af8f06c4465216f-893264534.us-east-2.elb.amazonaws.com
+Port:                     <unset>  80/TCP
+TargetPort:               80/TCP
+NodePort:                 <unset>  31997/TCP
+Endpoints:                100.96.4.21:80,100.96.6.19:80
+Session Affinity:         None
+External Traffic Policy:  Cluster
+Events:
+  Type    Reason                Age   From                Message
+  ----    ------                ----  ----                -------
+  Normal  CreatingLoadBalancer  9s    service-controller  Creating load balancer
+  Normal  CreatedLoadBalancer   8s    service-controller  Created load balancer
+```
+It will take a few minutes for the load balancer to be created and attached to the nodes.
+
+In addition to seeing the hostname via the desribe operation, we can also retrieve just the hostname of the load balancer via:
+
+    $ kubectl get service web -o jsonpath={.status.loadBalancer.ingress..hostname}
+    ae70e9781d70e11e7af8f06c4465216f-893264534.us-east-2.elb.amazonaws.com
+
+Just as before, you can point a browser or `cURL` to that hostname (this time on port 80) and you should see the NGiNX homepage.
 
 === Delete resources
 

--- a/getting-started/readme.adoc
+++ b/getting-started/readme.adoc
@@ -160,7 +160,7 @@ This command will open a TTY to a shell in your pod:
 
 This opens a Bash shell and allows you to look around the filesystem of the container.
 
-=== Expose the deployment as a service (via NodePort)
+== Expose the deployment as a service (via NodePort)
 
 By default, all Kubernetes resources are only accessible within the cluster. This command will create a loadBalancer and allow the the NGiNX deployment to be accessible from the Internet:
 
@@ -175,7 +175,7 @@ This will expose the deployment as a Service. You can see the published service:
 
 We will learn more about Services and Deployments later in the workshop.    
 
-== View the NGiNX deployment using the NodePort
+=== View the NGiNX deployment using the NodePort
 
 First, we find the hostname of the node on which the nginx Pod is running: 
 
@@ -242,7 +242,7 @@ You should now be able to point a browser or use `cURL` to retrieve the combined
 
     <p><em>Thank you for using nginx.</em></p> 
     
-=== Expose the deployment as a service via a load balancer
+== Expose the deployment as a service (via a Load Balancer)
 
 Delete the existing service and deployment:
 
@@ -285,7 +285,7 @@ Events:
 ```
 It will take a few minutes for the load balancer to be created and attached to the nodes.
 
-== View the deployment as a service via a load balancer
+=== View the deployment as a service via the Load Balancer
 
 In addition to seeing the hostname via the desribe operation, we can also retrieve just the hostname of the load balancer via:
 

--- a/getting-started/readme.adoc
+++ b/getting-started/readme.adoc
@@ -160,7 +160,7 @@ This command will open a TTY to a shell in your pod:
 
 This opens a Bash shell and allows you to look around the filesystem of the container.
 
-=== Expose the deployment as a service via NodePort
+=== Expose the deployment as a service (via NodePort)
 
 By default, all Kubernetes resources are only accessible within the cluster. This command will create a loadBalancer and allow the the NGiNX deployment to be accessible from the Internet:
 
@@ -175,7 +175,7 @@ This will expose the deployment as a Service. You can see the published service:
 
 We will learn more about Services and Deployments later in the workshop.    
 
-== View the NGiNX deployment via the NodePort
+== View the NGiNX deployment using the NodePort
 
 First, we find the hostname of the node on which the nginx Pod is running: 
 
@@ -193,7 +193,7 @@ Next we need the dynamic port the service opened for us on the Node running the 
     $ kubectl get service web -o jsonpath={.spec.ports..nodePort}
     32400
 
-Next, we need to open the port on the node itself to receive traffic that port. We do this by finding the security group to which the node belongs.
+Next, we need to authorize access on the port on the node itself to receive traffic. We do this by finding the node's security group, then using the AWS CLI to authorize ingress on that port.
 
    $ aws ec2 describe-instances --filters "Name=private-dns-name,Values=ip-172-20-87-91.us-east-2.compute.internal" --query 'Reservations[*].Instances[*].SecurityGroups[*].GroupId'
     [
@@ -204,6 +204,8 @@ Next, we need to open the port on the node itself to receive traffic that port. 
 
     $ aws ec2 authorize-security-group-ingress --group-id sg-c0285fa8 --protocol tcp --port 32400 --cidr 0.0.0.0/0
 
+Finally, we can use the AWS CLI to retrieve the public hostname of the node itself.
+
     $ aws ec2 describe-instances --filters "Name=private-dns-name,Values=ip-172-20-87-91.us-east-2.compute.internal" --query 'Reservations[*].Instances[*].NetworkInterfaces[*].PrivateIpAddresses[*].Association.PublicDnsName'
     [
         [
@@ -213,7 +215,7 @@ Next, we need to open the port on the node itself to receive traffic that port. 
         ]
     ]
 
-You should now be able to go to point a browser or use `curl` to go to the combined site and see the default NGiNX homepage:
+You should now be able to point a browser or use `cURL` to retrieve the combined <public hostname>:<node port> and see the default NGiNX homepage:
 
     $ curl http://ec2-18-216-5-70.us-east-2.compute.amazonaws.com:32400 
     <!DOCTYPE html>
@@ -240,7 +242,7 @@ You should now be able to go to point a browser or use `curl` to go to the combi
 
     <p><em>Thank you for using nginx.</em></p> 
     
-=== Expose a deployment as a service via a load balancer
+=== Expose the deployment as a service via a load balancer
 
 Delete the existing service and deployment:
 
@@ -283,6 +285,8 @@ Events:
 ```
 It will take a few minutes for the load balancer to be created and attached to the nodes.
 
+== View the deployment as a service via a load balancer
+
 In addition to seeing the hostname via the desribe operation, we can also retrieve just the hostname of the load balancer via:
 
     $ kubectl get service web -o jsonpath={.status.loadBalancer.ingress..hostname}
@@ -290,9 +294,13 @@ In addition to seeing the hostname via the desribe operation, we can also retrie
 
 Just as before, you can point a browser or `cURL` to that hostname (this time on port 80) and you should see the NGiNX homepage.
 
-=== Delete resources
+=== Delete resources and clean up
 
 Delete all the Kubernetes resources created so far:
 
     $ kubectl delete service/web deployment/nginx
+
+Revoke access on the port you opened on the EC2 security group earlier:
+
+    $ aws ec2 revoke-security-group-ingress --group-id sg-c0285fa8 --protocol tcp --port 32400 --cidr 0.0.0.0/0
 

--- a/getting-started/readme.adoc
+++ b/getting-started/readme.adoc
@@ -10,7 +10,7 @@ Before starting this section, please have created  a highly available cluster on
 
 Now that we have a cluster up and running we can start issuing some basic commands and deploy some simple resources.
 
-In this part we will familiarize ourselves with the `kubectl` CLI tool and basic Kubernetes commands. We will first deploy a basic NGINX pod and execute some commands to help developers gain comfort with the Kubernetes environment from an end-user perspective. This helps get developers up and running taking advantage of the Kubernetes application deployment capabilities without having to worry about the infrastructure related complexities.
+In this part we will familiarize ourselves with the `kubectl` CLI tool and basic Kubernetes commands. We will first deploy a basic NGiNX pod and execute some commands to help developers gain comfort with the Kubernetes environment from an end-user perspective. This helps get developers up and running taking advantage of the Kubernetes application deployment capabilities without having to worry about the infrastructure related complexities.
 
 NOTE: The kubectl commands below will be routed via your virtualbox network interface. If you are using a VPN or have a local firewall, this may prevent kubectl from contacting the minikube endpoint. Stopping the VPN or adding a firewall rule may resolve this.
 
@@ -18,18 +18,26 @@ NOTE: The kubectl commands below will be routed via your virtualbox network inte
 
 This command will show all the nodes available in your kubernetes cluster:
 
-    kubectl get nodes
+    $ kubectl get nodes
 
-It shows the output as:
+It will show an output similar to:
 
-  NAME       STATUS    ROLES     AGE       VERSION
-
+    NAME                                           STATUS    ROLES     AGE      VERSION
+    ip-172-20-105-158.us-east-2.compute.internal   Ready     node      2d       v1.7.4
+    ip-172-20-124-26.us-east-2.compute.internal    Ready     master    2d       v1.7.4
+    ip-172-20-127-251.us-east-2.compute.internal   Ready     node      2d       v1.7.4
+    ip-172-20-52-35.us-east-2.compute.internal     Ready     master    2d       v1.7.4
+    ip-172-20-63-150.us-east-2.compute.internal    Ready     node      2d       v1.7.4
+    ip-172-20-71-14.us-east-2.compute.internal     Ready     node      2d       v1.7.4
+    ip-172-20-87-91.us-east-2.compute.internal     Ready     node      2d       v1.7.4
+    ip-172-20-94-153.us-east-2.compute.internal    Ready     master    2d       v1.7.4
 
 === Create your first pod
 
 This command creates an nginx pod into your cluster:
 
-    kubectl run nginx --image=nginx
+    $ kubectl run nginx --image=nginx
+    deployment "nginx" created
 
 Get the list of deployments:
 
@@ -41,210 +49,146 @@ Get the list of running pods:
 
     $ kubectl get pods
     NAME                     READY     STATUS    RESTARTS   AGE
-    nginx-4217019353-h7mns   1/1       Running   0          1m
+    nginx-4217019353-pmkzb   1/1       Running   0          1m
 
 Get additional details for the pod by using the `<pod-name>` from the above output:
 
 ```
-$ kubectl describe pod/nginx-4217019353-h7mns
-Name:           nginx-4217019353-h7mns
+$ kubectl describe pod/nginx-4217019353-pmkzb
+kubectl describe pod/nginx-4217019353-pmkzb
+Name:           nginx-4217019353-pmkzb
 Namespace:      default
-Node:           minikube/192.168.99.100
-Start Time:     Sun, 22 Oct 2017 21:19:07 -0400
+Node:           ip-172-20-87-91.us-east-2.compute.internal/172.20.87.91
+Start Time:     Fri, 01 Dec 2017 16:36:48 -0800
 Labels:         pod-template-hash=4217019353
                 run=nginx
-Annotations:    kubernetes.io/created-by={"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicaSet","namespace":"default","name":"nginx-4217019353","uid":"2ac75475-b790-11e7-98ed-08002724bd66","...
+Annotations:    kubernetes.io/created-by={"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicaSet","namespace":"default","name":"nginx-4217019353","uid":"e161abe9-d6f8-11e7-af8f-06c4465216f2","...
+                kubernetes.io/limit-ranger=LimitRanger plugin set: cpu request for container nginx
 Status:         Running
-IP:             172.17.0.6
+IP:             100.96.7.19
 Created By:     ReplicaSet/nginx-4217019353
 Controlled By:  ReplicaSet/nginx-4217019353
 Containers:
   nginx:
-    Container ID:   docker://75ac01bf97fee66ea8e5cfd6cfe00d3b29d8b09d9ca52b7be1782db5dd610057
+    Container ID:   docker://2def6a6dc1594c337748abf6160ff81fab9fa6d734aca02b5f1afc4d395edc6b
     Image:          nginx
-    Image ID:       docker://sha256:1e5ab59102ce46c277eda5ed77affaa4e3b06a59fe209fe0b05200606db3aa7a
+    Image ID:       docker-pullable://nginx@sha256:b81f317384d7388708a498555c28a7cce778a8f291d90021208b3eba3fe74887
     Port:           <none>
     State:          Running
-      Started:      Sun, 22 Oct 2017 21:20:02 -0400
+      Started:      Fri, 01 Dec 2017 16:36:52 -0800
     Ready:          True
     Restart Count:  0
-    Environment:    <none>
+    Requests:
+      cpu:        100m
+    Environment:  <none>
     Mounts:
-      /var/run/secrets/kubernetes.io/serviceaccount from default-token-c5xdg (ro)
+      /var/run/secrets/kubernetes.io/serviceaccount from default-token-cqht0 (ro)
 Conditions:
   Type           Status
-  Initialized    True
-  Ready          True
-  PodScheduled   True
+  Initialized    True 
+  Ready          True 
+  PodScheduled   True 
 Volumes:
-  default-token-c5xdg:
+  default-token-cqht0:
     Type:        Secret (a volume populated by a Secret)
-    SecretName:  default-token-c5xdg
+    SecretName:  default-token-cqht0
     Optional:    false
-QoS Class:       BestEffort
+QoS Class:       Burstable
 Node-Selectors:  <none>
-Tolerations:     <none>
+Tolerations:     node.alpha.kubernetes.io/notReady:NoExecute for 300s
+                 node.alpha.kubernetes.io/unreachable:NoExecute for 300s
 Events:
-  Type    Reason                 Age   From               Message
-  ----    ------                 ----  ----               -------
-  Normal  Scheduled              1m    default-scheduler  Successfully assigned nginx-4217019353-h7mns to minikube
-  Normal  SuccessfulMountVolume  1m    kubelet, minikube  MountVolume.SetUp succeeded for volume "default-token-c5xdg"
-  Normal  Pulling                1m    kubelet, minikube  pulling image "nginx"
-  Normal  Pulled                 51s   kubelet, minikube  Successfully pulled image "nginx"
-  Normal  Created                51s   kubelet, minikube  Created container
-  Normal  Started                51s   kubelet, minikube  Started container
+  Type    Reason                 Age   From                                                 Message
+  ----    ------                 ----  ----                                                 -------
+  Normal  Scheduled              46s   default-scheduler                                    Successfully assigned nginx-4217019353-pmkzb to ip-172-20-87-91.us-east-2.compute.internal
+  Normal  SuccessfulMountVolume  46s   kubelet, ip-172-20-87-91.us-east-2.compute.internal  MountVolume.SetUp succeeded for volume "default-token-cqht0"
+  Normal  Pulling                46s   kubelet, ip-172-20-87-91.us-east-2.compute.internal  pulling image "nginx"
+  Normal  Pulled                 42s   kubelet, ip-172-20-87-91.us-east-2.compute.internal  Successfully pulled image "nginx"
+  Normal  Created                42s   kubelet, ip-172-20-87-91.us-east-2.compute.internal  Created container
+  Normal  Started                42s   kubelet, ip-172-20-87-91.us-east-2.compute.internal  Started container
+
 ```
 
 By default, pods are created in a `default` namespace. In addition, a `kube-system` namespace is also reserved for Kubernetes system pods. A list of all the pods in `kube-system` namespace can be displayed as shown:
 
 ```
 $ kubectl get pods --namespace kube-system
-NAME                          READY     STATUS    RESTARTS   AGE
-kube-addon-manager-minikube   1/1       Running   0          1m
-kube-dns-1326421443-69xs9     3/3       Running   0          1m
-kubernetes-dashboard-5jt9q    1/1       Running   0          1m
+NAME                                                                  READY     STATUS    RESTARTS   AGE
+dns-controller-3497129722-4pxd6                                       1/1       Running   0          28d
+etcd-server-events-ip-172-20-124-26.us-east-2.compute.internal        1/1       Running   0          28d
+etcd-server-events-ip-172-20-52-35.us-east-2.compute.internal         1/1       Running   0          28d
+etcd-server-events-ip-172-20-94-153.us-east-2.compute.internal        1/1       Running   0          28d
+etcd-server-ip-172-20-124-26.us-east-2.compute.internal               1/1       Running   0          28d
+etcd-server-ip-172-20-52-35.us-east-2.compute.internal                1/1       Running   0          28d
+etcd-server-ip-172-20-94-153.us-east-2.compute.internal               1/1       Running   0          28d
+kube-apiserver-ip-172-20-124-26.us-east-2.compute.internal            1/1       Running   0          28d
+kube-apiserver-ip-172-20-52-35.us-east-2.compute.internal             1/1       Running   0          28d
+kube-apiserver-ip-172-20-94-153.us-east-2.compute.internal            1/1       Running   0          28d
+kube-controller-manager-ip-172-20-124-26.us-east-2.compute.internal   1/1       Running   0          28d
+kube-controller-manager-ip-172-20-52-35.us-east-2.compute.internal    1/1       Running   0          28d
+kube-controller-manager-ip-172-20-94-153.us-east-2.compute.internal   1/1       Running   0          28d
+kube-dns-1311260920-jgl0m                                             3/3       Running   0          28d
+kube-dns-1311260920-tvpmp                                             3/3       Running   0          28d
+kube-dns-autoscaler-1818915203-5kxrb                                  1/1       Running   0          28d
+kube-proxy-ip-172-20-105-158.us-east-2.compute.internal               1/1       Running   0          28d
+kube-proxy-ip-172-20-124-26.us-east-2.compute.internal                1/1       Running   0          28d
+kube-proxy-ip-172-20-127-251.us-east-2.compute.internal               1/1       Running   0          28d
+kube-proxy-ip-172-20-52-35.us-east-2.compute.internal                 1/1       Running   0          28d
+kube-proxy-ip-172-20-63-150.us-east-2.compute.internal                1/1       Running   0          28d
+kube-proxy-ip-172-20-71-14.us-east-2.compute.internal                 1/1       Running   0          28d
+kube-proxy-ip-172-20-87-91.us-east-2.compute.internal                 1/1       Running   0          28d
+kube-proxy-ip-172-20-94-153.us-east-2.compute.internal                1/1       Running   0          28d
+kube-scheduler-ip-172-20-124-26.us-east-2.compute.internal            1/1       Running   0          28d
+kube-scheduler-ip-172-20-52-35.us-east-2.compute.internal             1/1       Running   0          28d
+kube-scheduler-ip-172-20-94-153.us-east-2.compute.internal            1/1       Running   0          28d
+tiller-deploy-1114875906-k2pj2                                        1/1       Running   0          28d
 ```
+Again, the exact output may vary but your results should look similar to these.
 
 === Get logs from the pod
 
 Logs from the pod can be obtained (a fresh nginx does not have logs - check again later once you have accessed the service):
 
-    kubectl logs <pod-name>
+    $ kubectl logs <pod-name>
 
 === Execute a shell on the running pod
 
 This command will open a TTY to a shell in your pod:
 
-    kubectl get pods
-    kubectl exec -it <pod-name> /bin/bash
+    $ kubectl get pods
+    $ kubectl exec -it <pod-name> /bin/bash
 
 This opens a Bash shell and allows you to look around the filesystem of the container.
 
-=== Expose pod
+=== Expose the deployment as a Service
 
-By default, all Kubernetes resources are only accessible within the cluster. This command will publish the NGINX pod to a port on the host where it's deployed:
+By default, all Kubernetes resources are only accessible within the cluster. This command will create a loadBalancer and allow the the NGiNX deployment to be accessible from the Internet:
 
-    kubectl expose pod <pod-name> --port=80 --type=NodePort --name=web
+    $ kubectl expose deployment nginx --type=LoadBalancer --port=80 --target-port=80 --name=web
+    service "web" exposed
 
-Where `<pod-name>` is the pod name of your NGINX pod. This will expose the pod as a Service. You can see the published service:
+This will expose the deployment as a Service. You can see the published service:
 
-    $ kubectl get svc
-    NAME         TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)        AGE
-    kubernetes   ClusterIP   10.0.0.1     <none>        443/TCP        50m
-    web          NodePort    10.0.0.138   <none>        80:32406/TCP   3s
+    $ kubectl get service
+    NAME         TYPE           CLUSTER-IP      EXTERNAL-IP        PORT(S)        AGE
+    kubernetes   ClusterIP      100.64.0.1      <none>             443/TCP        2d
+    web          LoadBalancer   100.69.223.33   a904073d0d6fe...   80:31259/TCP   32s
 
-=== View service webpage
+We will learn more about Services and Deployments later in the workshop.    
 
-You can view the IP address of a node in your cluster with these steps, first find all of the nodes in your cluster:
+=== View Service webpage
 
-    kubectl get nodes
+We can find the hostname of the LoadBalancer created when we exposed the nginx deployment as service.
+The `-o` flag allows us to choose a different output format, and choosing the `jsonpath` output format allows us to filter the resultant JSON down to the exact value we need. 
 
-Once you have the nodes (in minikubes case there will be only one), we can describe all of the attribute of that node with:
+    $ kubectl get service web -o jsonpath={.status.loadBalancer.ingress..hostname}
+    a904073d0d6fe11e7af8f06c4465216f-766639162.us-east-2.elb.amazonaws.com
 
-    kubectl describe node <node-name>
-
-Where `<node-name>` is the output from the previous command. This shows a lot of information about the node:
-
-```
-$ kubectl describe node minikube
-Name:               minikube
-Roles:              <none>
-Labels:             beta.kubernetes.io/arch=amd64
-                    beta.kubernetes.io/os=linux
-                    kubernetes.io/hostname=minikube
-Annotations:        alpha.kubernetes.io/provided-node-ip=192.168.99.100
-                    node.alpha.kubernetes.io/ttl=0
-                    volumes.kubernetes.io/controller-managed-attach-detach=true
-Taints:             <none>
-CreationTimestamp:  Sun, 15 Oct 2017 17:22:22 -0400
-Conditions:
-  Type             Status  LastHeartbeatTime                 LastTransitionTime                Reason                       Message
-  ----             ------  -----------------                 ------------------                ------                       -------
-  OutOfDisk        False   Sun, 22 Oct 2017 21:26:44 -0400   Mon, 16 Oct 2017 19:28:57 -0400   KubeletHasSufficientDisk     kubelet has sufficient disk space available
-  MemoryPressure   False   Sun, 22 Oct 2017 21:26:44 -0400   Mon, 16 Oct 2017 19:28:57 -0400   KubeletHasSufficientMemory   kubelet has sufficient memory available
-  DiskPressure     False   Sun, 22 Oct 2017 21:26:44 -0400   Mon, 16 Oct 2017 19:28:57 -0400   KubeletHasNoDiskPressure     kubelet has no disk pressure
-  Ready            True    Sun, 22 Oct 2017 21:26:44 -0400   Mon, 16 Oct 2017 19:28:57 -0400   KubeletReady                 kubelet is posting ready status
-Addresses:
-  InternalIP:  192.168.99.100
-  Hostname:    minikube
-Capacity:
- cpu:     2
- memory:  2048484Ki
- pods:    110
-Allocatable:
- cpu:     2
- memory:  1946084Ki
- pods:    110
-System Info:
- Machine ID:                 6756b9ba9cd3480fa019cf553d4fea04
- System UUID:                AC4BE6D4-7896-46EF-B921-44BD0BC92D0D
- Boot ID:                    66a504af-ce10-4d45-ad50-334f21a2063e
- Kernel Version:             4.7.2
- OS Image:                   Buildroot 2016.08
- Operating System:           linux
- Architecture:               amd64
- Container Runtime Version:  docker://1.11.1
- Kubelet Version:            v1.7.5
- Kube-Proxy Version:         v1.7.5
-ExternalID:                  minikube
-Non-terminated Pods:         (4 in total)
-  Namespace                  Name                           CPU Requests  CPU Limits  Memory Requests  Memory Limits
-  ---------                  ----                           ------------  ----------  ---------------  -------------
-  default                    nginx-4217019353-h7mns         0 (0%)        0 (0%)      0 (0%)           0 (0%)
-  kube-system                kube-addon-manager-minikube    5m (0%)       0 (0%)      50Mi (2%)        0 (0%)
-  kube-system                kube-dns-1326421443-tbzqc      260m (13%)    0 (0%)      110Mi (5%)       170Mi (8%)
-  kube-system                kubernetes-dashboard-zqd7w     0 (0%)        0 (0%)      0 (0%)           0 (0%)
-Allocated resources:
-  (Total limits may be over 100 percent, i.e., overcommitted.)
-  CPU Requests  CPU Limits  Memory Requests  Memory Limits
-  ------------  ----------  ---------------  -------------
-  265m (13%)    0 (0%)      160Mi (8%)       170Mi (8%)
-Events:
-  Type     Reason                   Age              From                  Message
-  ----     ------                   ----             ----                  -------
-  Normal   Starting                 6d               kubelet, minikube     Starting kubelet.
-  Normal   NodeAllocatableEnforced  6d               kubelet, minikube     Updated Node Allocatable limit across pods
-  Warning  Rebooted                 6d               kubelet, minikube     Node minikube has been rebooted, boot id: d80f975d-2373-4fd0-9d11-3262049e1f39
-  Normal   NodeNotReady             6d               kubelet, minikube     Node minikube status is now: NodeNotReady
-  Normal   Starting                 6d               kube-proxy, minikube  Starting kube-proxy.
-  Normal   NodeHasSufficientDisk    6d (x2 over 6d)  kubelet, minikube     Node minikube status is now: NodeHasSufficientDisk
-  Normal   NodeHasSufficientMemory  6d (x2 over 6d)  kubelet, minikube     Node minikube status is now: NodeHasSufficientMemory
-  Normal   NodeHasNoDiskPressure    6d (x2 over 6d)  kubelet, minikube     Node minikube status is now: NodeHasNoDiskPressure
-  Normal   NodeReady                6d (x2 over 6d)  kubelet, minikube     Node minikube status is now: NodeReady
-  Normal   Starting                 8m               kubelet, minikube     Starting kubelet.
-  Normal   NodeAllocatableEnforced  8m               kubelet, minikube     Updated Node Allocatable limit across pods
-  Normal   NodeHasSufficientDisk    8m               kubelet, minikube     Node minikube status is now: NodeHasSufficientDisk
-  Normal   NodeHasSufficientMemory  8m               kubelet, minikube     Node minikube status is now: NodeHasSufficientMemory
-  Normal   NodeHasNoDiskPressure    8m               kubelet, minikube     Node minikube status is now: NodeHasNoDiskPressure
-  Warning  Rebooted                 8m               kubelet, minikube     Node minikube has been rebooted, boot id: 66a504af-ce10-4d45-ad50-334f21a2063e
-  Normal   Starting                 8m               kube-proxy, minikube  Starting kube-proxy.
-```
-
-IP address information can be obtained by looking at the `InternalIP` field:
-
-    $ echo $(kubectl get nodes -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
-
-This gives us the IP address where the service is hosted. Now, we need to get the port that the service is exposed on. This can be found using the following command:
-
-    $ echo $(kubectl get service web -o jsonpath='{.spec.ports[*].nodePort}')
-
-We can combine these two commands with curl to access the service from the cli:
-```
-$ curl $(kubectl get nodes -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}'):$(kubectl get service web -o jsonpath='{.spec.ports[*].nodePort}')
-```
-
-The host and the port are the exact same values where minikube opened the service page in the browser.
-
-=== Kubernetes dashboard
-
-Kubernetes dashboard is a general purpose, web-based UI for Kubernetes clusters. It provides an overview of applications running on the cluster, as well as the ability to create or modify individual Kubernetes resources and workloads, such as replica sets, jobs, services, and pods. The dashboard can be used to manage the cluster as well.
-
-Look around the dashboard and become familiar with some of the Kubernetes terminology. This will be explained in the subsequent chapters.
-
+Placing that hostname into a browser should show the default NGiNX homepage.
 
 === Delete resources
 
-Delete the Kubernetes resources created so far:
+Delete all the Kubernetes resources created so far:
 
-    kubectl delete svc/web deployment/nginx
+    $ kubectl delete service/web deployment/nginx
 

--- a/getting-started/readme.adoc
+++ b/getting-started/readme.adoc
@@ -235,12 +235,10 @@ You should now be able to point a browser or use `cURL` to retrieve the combined
     <h1>Welcome to nginx!</h1>
     <p>If you see this page, the nginx web server is successfully installed and
     working. Further configuration is required.</p>
-
     <p>For online documentation and support please refer to
     <a href="http://nginx.org/">nginx.org</a>.<br/>
     Commercial support is available at
     <a href="http://nginx.com/">nginx.com</a>.</p>
-
     <p><em>Thank you for using nginx.</em></p> 
     
 == Expose the deployment as a service (via a Load Balancer)

--- a/getting-started/readme.adoc
+++ b/getting-started/readme.adoc
@@ -32,7 +32,7 @@ It will show an output similar to:
 
 === Create your first pod
 
-This command creates an nginx pod into your cluster:
+This command instantiates an nginx container into your cluster, inside a pod:
 
     $ kubectl run nginx --image=nginx
     deployment "nginx" created
@@ -156,16 +156,16 @@ This command will open a TTY to a shell in your pod:
     $ kubectl get pods
     $ kubectl exec -it <pod-name> /bin/bash
 
-This opens a Bash shell and allows you to look around the filesystem of the container.
+This opens a bash shell and allows you to look around the filesystem of the container.
 
 == Expose the deployment as a service (via NodePort)
 
-By default, all Kubernetes resources are only accessible within the cluster. This command will create a loadBalancer and allow the the NGiNX deployment to be accessible from the Internet:
+By default, all Kubernetes resources are only accessible within the cluster. This command will expose the pod via a dynamically chosen port on the node itself.  This will eventually allow the the NGiNX deployment to be accessible from the Internet:
 
     $ kubectl expose deployment nginx --type=NodePort --port=80 --target-port=80 --name=web
     service "web" exposed
 
-This will expose the deployment as a Service. You can see the published service:
+Expose the deployment creates what Kubernetes calls a service. You can see the published service:
 
     $ kubectl get service
     NAME         TYPE           CLUSTER-IP      EXTERNAL-IP        PORT(S)        AGE
@@ -186,12 +186,13 @@ First, we find the hostname of the node on which the nginx Pod is running:
 
 The `-o` flag allows us to choose a different output format, and choosing the `jsonpath` output format allows us to filter the resultant JSON down to the exact value we need. 
 
-Next we need the dynamic port the service opened for us on the Node running the NGiNX pod.
+Next we need the dynamic port the service opened for us on the node running the NGiNX pod.
 
     $ kubectl get service web -o jsonpath={.spec.ports..nodePort}
     32400
 
 Next, we need to authorize access on the port on the node itself to receive traffic. We do this by finding the node's security group, then using the AWS CLI to authorize ingress on that port.
+Replace the `Values` value with the nodeName retreived earlier.
 
    $ aws ec2 describe-instances --filters "Name=private-dns-name,Values=ip-172-20-87-91.us-east-2.compute.internal" --query 'Reservations[*].Instances[*].SecurityGroups[*].GroupId'
     [
@@ -199,6 +200,8 @@ Next, we need to authorize access on the port on the node itself to receive traf
             "sg-c0285fa8"
         ]
     ]    
+
+Next, we add an ingress rule to the security group opening up the port on the node to anyone - `0.0.0.0/0`. This is purely for demonstration purposes in this workshop and is not a best practice. Most services will be exposed behind a load balancer, which we cover in the next section.  For the command below, replace the `--port` flag value with the nodePort retreived above.
 
     $ aws ec2 authorize-security-group-ingress --group-id sg-c0285fa8 --protocol tcp --port 32400 --cidr 0.0.0.0/0
 

--- a/local-development/readme.adoc
+++ b/local-development/readme.adoc
@@ -1,139 +1,194 @@
-= Kubernetes - First Steps with the Kubernetes CLI
+= Kubernetes - Setup Local Development Environment
 :icons:
 :linkcss:
 :imagesdir: ../images
 :toc:
 
-Before starting this section, please have created  a highly available cluster on AWS using https://github.com/kubernetes/kops[kops], as explained here: link:../cluster-install[cluster install] section.
+For local development purposes, you can create a one-node cluster using https://github.com/kubernetes/minikube[Minikube]. 
+Hosted solutions or cloud-based solutions provide the scalability and higher availability for staging or production purposes. 
+A complete list of solutions to create a Kubernetes cluster is explained at http://kubernetes.io/docs/getting-started-guides/.
 
-== Kubernetes basic commands
+This section will explain how to create and shutdown a development Kubernetes cluster using Minikube. 
 
-Now that we have a cluster up and running we can start issuing some basic commands and deploy some simple resources.
+== Download and Install
 
-In this part we will familiarize ourselves with the `kubectl` CLI tool and basic Kubernetes commands. We will first deploy a basic NGINX pod and execute some commands to help developers gain comfort with the Kubernetes environment from an end-user perspective. This helps get developers up and running taking advantage of the Kubernetes application deployment capabilities without having to worry about the infrastructure related complexities.
+Minikube runs a single-node Kubernetes cluster inside a VM on your laptop. 
+This allows you to easily try out Kubernetes on your local machine. 
+Minikube packages and configures a Linux VM, the container runtime, and all Kubernetes components - optimized for local development.
 
-NOTE: The kubectl commands below will be routed via your virtualbox network interface. If you are using a VPN or have a local firewall, this may prevent kubectl from contacting the minikube endpoint. Stopping the VPN or adding a firewall rule may resolve this.
+Complete installation instructions are available at https://github.com/kubernetes/minikube. Here are quick instructions:
 
-=== Display nodes
+=== Setup on macOS
 
-This command will show all the nodes available in your kubernetes cluster:
+Provision and install a local Kubernetes cluster on a Mac OS via https://brew.sh/[homebrew].
 
-    kubectl get nodes
+. Install VirtualBox
 
-It shows the output as:
+    brew cask install virtualbox
 
-  NAME       STATUS    ROLES     AGE       VERSION
+. Install minikube
+
+    brew cask install minikube
++
+If `minikube` has already been installed earlier, then you can update the install using the following command:
++
+    brew cask reinstall minikube
++
+If you receive this error after `brew cask install minikube`:
++
+    ==> Installing Cask minikube
+    Error: It seems there is already a Binary at '/usr/local/bin/minikube'; not linking.
++
+Run this command:
++
+    $ sudo cp ~/Library/Caches/Homebrew/Cask/minikube--0.23.0 /usr/local/bin/minikube
++
+Verify the version:
++
+    $ minikube version
+    minikube version: v0.23.0
++
+. Install Kubectl CLI
+
+    brew install kubernetes-cli
++
+If you already have Kubectl CLI installed, then you just need to update it:
++
+    brew upgrade kubernetes-cli
+
+=== Setup on Windows
+
+. Download and install https://www.virtualbox.org/wiki/Downloads[VirtualBox].
+. Download the https://storage.googleapis.com/minikube/releases/latest/minikube-windows-amd64.exe[minikube-windows-amd64.exe] file, and rename it to `minikube.exe`.
++
+Verify the version:
++
+    $ minikube version
+    minikube version: v0.23.0
++
+. Download kubectl CLI with cmd.exe
++
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.goo \
+    gleapis.com/kubernetes-release/release/stable.txt)/bin/windows/amd64/kubectl.exe
+
+Latest instructions are also available at https://kubernetes.io/docs/tasks/tools/install-kubectl/#before-you-begin.
+
+=== Setup on Linux
+
+. Download and install https://www.virtualbox.org/wiki/Downloads[VirtualBox].
+. Install minikube:
++
+    curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
++
+Verify the version:
++
+    $ minikube version
+    minikube version: v0.23.0
++
+. Install or Upgrade Kubectl CLI:
++
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+    chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 
 
-=== Create your first pod
+=== Setup on EC2 (if you do not virtualbox on your laptop)
 
-This command creates an nginx pod into your cluster:
+. Launch an EC2 (at least 4GB Memory) with an "Ubuntu Server 16.04 LTS (HVM)" AMI, make sure you have a public IP and can SSH into this instance.
+. SSH into the EC2 (the port forwarding is for the minikube dashboard):
++
+    ssh -L30000:localhost:30000 ubuntu@<IP Address of EC2>
++
 
-    kubectl run nginx --image=nginx
+. Install docker
++
+    sudo -i
+    apt-get update -y &&  apt-get install -y docker.io
++
 
-Get the list of deployments:
+. Install minikube:
++
+    curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
++
 
-    $ kubectl get deployments
-    NAME      DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-    nginx     1         1         1            0           41s
+Verify the version:
++
+    $ minikube version
+    minikube version: v0.23.0
++
+. Install or Upgrade Kubectl CLI:
++
+    curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
++
 
-Get the list of running pods:
+. Add kubectl autocompletion to your current shell
++
+    source <(kubectl completion bash)
 
-    $ kubectl get pods
-    NAME                     READY     STATUS    RESTARTS   AGE
-    nginx-4217019353-h7mns   1/1       Running   0          1m
+== Start Kubernetes cluster
 
-Get additional details for the pod by using the `<pod-name>` from the above output:
+We are using the VirtualBox driver which is the default selection for minikube. If you would prefer you can use an alternate supported component (xhyve driver or VMware Fusion) using the `--vm-driver=xxx` flag.
+
+Start a single-node Kubernetes cluster on your local machine:
 
 ```
-$ kubectl describe pod/nginx-4217019353-h7mns
-Name:           nginx-4217019353-h7mns
-Namespace:      default
-Node:           minikube/192.168.99.100
-Start Time:     Sun, 22 Oct 2017 21:19:07 -0400
-Labels:         pod-template-hash=4217019353
-                run=nginx
-Annotations:    kubernetes.io/created-by={"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicaSet","namespace":"default","name":"nginx-4217019353","uid":"2ac75475-b790-11e7-98ed-08002724bd66","...
-Status:         Running
-IP:             172.17.0.6
-Created By:     ReplicaSet/nginx-4217019353
-Controlled By:  ReplicaSet/nginx-4217019353
-Containers:
-  nginx:
-    Container ID:   docker://75ac01bf97fee66ea8e5cfd6cfe00d3b29d8b09d9ca52b7be1782db5dd610057
-    Image:          nginx
-    Image ID:       docker://sha256:1e5ab59102ce46c277eda5ed77affaa4e3b06a59fe209fe0b05200606db3aa7a
-    Port:           <none>
-    State:          Running
-      Started:      Sun, 22 Oct 2017 21:20:02 -0400
-    Ready:          True
-    Restart Count:  0
-    Environment:    <none>
-    Mounts:
-      /var/run/secrets/kubernetes.io/serviceaccount from default-token-c5xdg (ro)
-Conditions:
-  Type           Status
-  Initialized    True
-  Ready          True
-  PodScheduled   True
-Volumes:
-  default-token-c5xdg:
-    Type:        Secret (a volume populated by a Secret)
-    SecretName:  default-token-c5xdg
-    Optional:    false
-QoS Class:       BestEffort
-Node-Selectors:  <none>
-Tolerations:     <none>
-Events:
-  Type    Reason                 Age   From               Message
-  ----    ------                 ----  ----               -------
-  Normal  Scheduled              1m    default-scheduler  Successfully assigned nginx-4217019353-h7mns to minikube
-  Normal  SuccessfulMountVolume  1m    kubelet, minikube  MountVolume.SetUp succeeded for volume "default-token-c5xdg"
-  Normal  Pulling                1m    kubelet, minikube  pulling image "nginx"
-  Normal  Pulled                 51s   kubelet, minikube  Successfully pulled image "nginx"
-  Normal  Created                51s   kubelet, minikube  Created container
-  Normal  Started                51s   kubelet, minikube  Started container
+    minikube start
 ```
 
-By default, pods are created in a `default` namespace. In addition, a `kube-system` namespace is also reserved for Kubernetes system pods. A list of all the pods in `kube-system` namespace can be displayed as shown:
+if you have installed minikube on a EC2, start it with the --vm-driver=none flag
 
 ```
-$ kubectl get pods --namespace kube-system
-NAME                          READY     STATUS    RESTARTS   AGE
-kube-addon-manager-minikube   1/1       Running   0          1m
-kube-dns-1326421443-69xs9     3/3       Running   0          1m
-kubernetes-dashboard-5jt9q    1/1       Running   0          1m
+    minikube start --vm-driver=none
 ```
 
-=== Get logs from the pod
+The first start of minikube will download the ISO file and then start the cluster. It shows the following output:
 
-Logs from the pod can be obtained (a fresh nginx does not have logs - check again later once you have accessed the service):
+```
+$ minikube start
+Starting local Kubernetes v1.8.0 cluster...
+Starting VM...
+Downloading Minikube ISO
+ 140.01 MB / 140.01 MB [============================================] 100.00% 0s
+Getting VM IP address...
+Moving files into cluster...
+Downloading localkube binary
+ 148.56 MB / 148.56 MB [============================================] 100.00% 0s
+Setting up certs...
+Connecting to cluster...
+Setting up kubeconfig...
+Starting cluster components...
+Kubectl is now configured to use the cluster.
+```
 
-    kubectl logs <pod-name>
+Now you can start to develop and test your application.
 
-=== Execute a shell on the running pod
+=== Check status
 
-This command will open a TTY to a shell in your pod:
+Check the status of minikube to get the status of your local Kubernetes cluster:
 
-    kubectl get pods
-    kubectl exec -it <pod-name> /bin/bash
+```
+$ minikube status
+minikube: Running
+cluster: Running
+kubectl: Correctly Configured: pointing to minikube-vm at 192.168.99.100
+```
 
-This opens a Bash shell and allows you to look around the filesystem of the container.
+Kubectl CLI is configured to talk to this cluster.
 
-=== Expose pod
+== Get information about the minikube cluster
 
-By default, all Kubernetes resources are only accessible within the cluster. This command will publish the NGINX pod to a port on the host where it's deployed:
-
-    kubectl expose pod <pod-name> --port=80 --type=NodePort --name=web
-
-Where `<pod-name>` is the pod name of your NGINX pod. This will expose the pod as a Service. You can see the published service:
-
-    $ kubectl get svc
-    NAME         TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)        AGE
-    kubernetes   ClusterIP   10.0.0.1     <none>        443/TCP        50m
-    web          NodePort    10.0.0.138   <none>        80:32406/TCP   3s
+Now that we have a local development cluster up and running we can start issuing some basic commands to see its status.
 
 === View service webpage
+
+This minikube command will display the service for you in a web page:
+
+    minikube service web
+
+This opened a browser with an IP address and the port that the service was exposed on. It looks like as shown:
+
+image::nginx-welcome-page.png[]
+
+This is a convenient feature of minikube. But what if you wanted to find this information yourself?
 
 You can view the IP address of a node in your cluster with these steps, first find all of the nodes in your cluster:
 
@@ -239,12 +294,20 @@ The host and the port are the exact same values where minikube opened the servic
 
 Kubernetes dashboard is a general purpose, web-based UI for Kubernetes clusters. It provides an overview of applications running on the cluster, as well as the ability to create or modify individual Kubernetes resources and workloads, such as replica sets, jobs, services, and pods. The dashboard can be used to manage the cluster as well.
 
+Kubernetes dashboard with minikube can be easily viewed using the following command ( Do not run this if you have minikube on EC2, instead just point your browser to http://127.0.0.1:30000):
+
+    minikube dashboard
+
+It looks like this:
+
+image::minikube-dashboard.png[]
+
 Look around the dashboard and become familiar with some of the Kubernetes terminology. This will be explained in the subsequent chapters.
 
+=== Shutdown cluster
 
-=== Delete resources
+The cluster can be shutdown using the following command:
 
-Delete the Kubernetes resources created so far:
-
-    kubectl delete svc/web deployment/nginx
-
+    $ minikube stop
+    Stopping local Kubernetes cluster...
+    Machine stopped.

--- a/prereqs.adoc
+++ b/prereqs.adoc
@@ -61,31 +61,31 @@ Now you see your newly admin user and group together with the `Access key ID`. T
 To login from the console run `aws configure` and enter the required values. It will look like this:
 
 ```
-aws configure
+$ aws configure
 AWS Access Key ID [None]: *****
 AWS Secret Access Key [None]: *****
 Default region name [None]: eu-central-1
 Default output format [None]:
 ```
 
-=== Create IAM user for workshop
+=== Create an IAM user with necessary permissions
 
 Run the following commands on CLI to create the needed group and user:
 
 ```
-aws iam create-group --group-name k8s-workshop
+$ aws iam create-group --group-name k8s-workshop
 
-aws iam attach-group-policy --policy-arn arn:aws:iam::aws:policy/AmazonEC2FullAccess --group-name k8s-workshop
-aws iam attach-group-policy --policy-arn arn:aws:iam::aws:policy/AmazonRoute53FullAccess --group-name k8s-workshop
-aws iam attach-group-policy --policy-arn arn:aws:iam::aws:policy/AmazonS3FullAccess --group-name k8s-workshop
-aws iam attach-group-policy --policy-arn arn:aws:iam::aws:policy/IAMFullAccess --group-name k8s-workshop
-aws iam attach-group-policy --policy-arn arn:aws:iam::aws:policy/AmazonVPCFullAccess --group-name k8s-workshop
+$ aws iam attach-group-policy --policy-arn arn:aws:iam::aws:policy/AmazonEC2FullAccess --group-name k8s-workshop
+$ aws iam attach-group-policy --policy-arn arn:aws:iam::aws:policy/AmazonRoute53FullAccess --group-name k8s-workshop
+$ aws iam attach-group-policy --policy-arn arn:aws:iam::aws:policy/AmazonS3FullAccess --group-name k8s-workshop
+$ aws iam attach-group-policy --policy-arn arn:aws:iam::aws:policy/IAMFullAccess --group-name k8s-workshop
+$ aws iam attach-group-policy --policy-arn arn:aws:iam::aws:policy/AmazonVPCFullAccess --group-name k8s-workshop
 
-aws iam create-user --user-name k8s-workshop
+$ aws iam create-user --user-name k8s-workshop
 
-aws iam add-user-to-group --user-name k8s-workshop --group-name k8s-workshop
+$ aws iam add-user-to-group --user-name k8s-workshop --group-name k8s-workshop
 
-aws iam create-access-key --user-name k8s-workshop
+$ aws iam create-access-key --user-name k8s-workshop
 ```
 
 Now run `aws configure` again and use the `Access Key ID` and `Secret Access Key` from the newly created user.
@@ -112,6 +112,6 @@ The workshop repo has configuration files that are used to create Kubernetes res
 
 	$ git clone https://github.com/aws-samples/aws-workshop-for-kubernetes
 
-== Need Help
+== Need Help? Found an Issue?
 
 Please https://github.com/aws-samples/aws-workshop-for-kubernetes/issues[file a bug] if you run into issues.

--- a/readme.adoc
+++ b/readme.adoc
@@ -23,9 +23,10 @@ as you move through the workshop.
 |Beginner (100 level)
 
 |link:prereqs.adoc[Prerequisites]
-|link:getting-started[Setup Development Environment and First Steps]
 |link:cluster-install[Create a Kubernetes cluster using kops]
+|link:getting-started[First Steps with the Kubernetes CLI]
 |link:developer-concepts[Kubernetes Developer Concepts]
+|link:local-development[(Optional) Set up Local Development Environment]
 |===
 
 [cols="1*"]

--- a/readme.adoc
+++ b/readme.adoc
@@ -26,7 +26,7 @@ as you move through the workshop.
 |link:cluster-install[Create a Kubernetes cluster using kops]
 |link:getting-started[First Steps with the Kubernetes CLI]
 |link:developer-concepts[Kubernetes Developer Concepts]
-|link:local-development[(Optional) Set up Local Development Environment]
+|link:local-development[(Optional) Configure a Local Development Environment]
 |===
 
 [cols="1*"]


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
These changes are based on feedback from supporting this workshop three times during Re:Invent 2017.
- Separated minikube section out into an (Optional) Configure a local development environment section.  Getting minikube to work out-of-the-box, especially on Windows or EC2, took a lot of time during the first workshop runs and often attendees just 'moved on' to kops without successfully launching minikube.  This change allows the instructions to remain but moves attendees quicker to creating a cluster on AWS via kops.
- Refactored cluster-install to promote a gossip-based cluster over a DNS-based one and marked the private VPC creation as (Optional.)  Getting a DNS cluster working correctly was also a source of frustration for attendees for many reasons.  Promoting a gossip-based cluster as the preferred way of creating the cluster allows for attendees to get into actually running kubernetes much faster.  Again, the DNS-based instructions are still there, they have just been moved into an Appendix at the bottom of the page.
- With the changes to minikube and cluster-install, I also reworked the getting-started page to use the kops-created cluster on AWS.  I added in exposing the nginx service via NodePort and also via a LoadBalancer.  
- Overall, the workshop is fantastic as is, but issues with minikube and DNS-based cluster setup tripped up quite a bit of attendees and, due to time constraints, potentially prevented them from going deeper into the workshop than they would have by diving straight into a gossip-based kops-created cluster on AWS.

I welcome any and all feedback and thoughts.  Thanks!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
