### PR TITLE
Fix link to kops 1.8.0; Fix link to kubectl install instructions

### DIFF
--- a/cluster-install/readme.adoc
+++ b/cluster-install/readme.adoc
@@ -3,7 +3,7 @@
 
 This tutorial will walk you through how to install a Kubernetes cluster on AWS using kops.
 
-https://github.com/kubernetes/kops[kops], short for Kubernetes Operations, is a set of tools for installing, operating, and deleting Kubernetes clusters. kops can also perform rolling upgrades from older versions of Kubernetes to newer ones. kops also manages the cluster add-ons. After the cluster is created, the link:https://kubernetes.io/docs/tasks/tools/install-kubectl/[Kubernetes CLI] can be used to manage resources in the cluster. If you have not installed the Kubernetes CLI before, please do so now before continuing.
+https://github.com/kubernetes/kops[kops], short for Kubernetes Operations, is a set of tools for installing, operating, and deleting Kubernetes clusters. kops can also perform rolling upgrades from older versions of Kubernetes to newer ones. kops also manages the cluster add-ons. After the cluster is created, the link:https://github.com/scottmalkie/kubernetes-aws-workshop/blob/master/prereqs.adoc[Kubernetes CLI] can be used to manage resources in the cluster. If you have not gone through the link:https://github.com/scottmalkie/kubernetes-aws-workshop/blob/master/prereqs.adoc[Prerequisites] section, please do so now before continuing.
 
 kops is available on Mac OSX, Linux, or the Windows 10 Linux Subsystem. 
 

--- a/cluster-install/readme.adoc
+++ b/cluster-install/readme.adoc
@@ -3,7 +3,7 @@
 
 This tutorial will walk you through how to install a Kubernetes cluster on AWS using kops.
 
-https://github.com/kubernetes/kops[kops], short for Kubernetes Operations, is a set of tools for installing, operating, and deleting Kubernetes clusters. kops can also perform rolling upgrades from older versions of Kubernetes to newer ones. kops also manages the cluster add-ons. After the cluster is created, the link:https://github.com/scottmalkie/kubernetes-aws-workshop/blob/master/prereqs.adoc[Kubernetes CLI] can be used to manage resources in the cluster. If you have not gone through the link:https://github.com/scottmalkie/kubernetes-aws-workshop/blob/master/prereqs.adoc[Prerequisites] section, please do so now before continuing.
+https://github.com/kubernetes/kops[kops], short for Kubernetes Operations, is a set of tools for installing, operating, and deleting Kubernetes clusters. kops can also perform rolling upgrades from older versions of Kubernetes to newer ones. kops also manages the cluster add-ons. After the cluster is created, the link:prereqs.adoc[Kubernetes CLI] can be used to manage resources in the cluster. If you have not gone through the link:prereqs.adoc[Prerequisites] section, please do so now before continuing.
 
 kops is available on Mac OSX, Linux, or the Windows 10 Linux Subsystem. 
 

--- a/cluster-install/readme.adoc
+++ b/cluster-install/readme.adoc
@@ -3,7 +3,7 @@
 
 This tutorial will walk you through how to install a Kubernetes cluster on AWS using kops.
 
-https://github.com/kubernetes/kops[kops], short for Kubernetes Operations, is a set of tools for installing, operating, and deleting Kubernetes clusters. kops can also perform rolling upgrades from older versions of Kubernetes to newer ones. kops also manages the cluster add-ons. After the cluster is created, the link:prereqs.adoc[Kubernetes CLI] can be used to manage resources in the cluster. If you have not gone through the link:prereqs.adoc[Prerequisites] section, please do so now before continuing.
+https://github.com/kubernetes/kops[kops], short for Kubernetes Operations, is a set of tools for installing, operating, and deleting Kubernetes clusters. kops can also perform rolling upgrades from older versions of Kubernetes to newer ones. kops also manages the cluster add-ons. After the cluster is created, the link:../prereqs.adoc[Kubernetes CLI] can be used to manage resources in the cluster. If you have not gone through the link:../prereqs.adoc[Prerequisites] section, please do so now before continuing.
 
 kops is available on Mac OSX, Linux, or the Windows 10 Linux Subsystem. 
 

--- a/cluster-install/readme.adoc
+++ b/cluster-install/readme.adoc
@@ -3,7 +3,7 @@
 
 This tutorial will walk you through how to install a Kubernetes cluster on AWS using kops.
 
-https://github.com/kubernetes/kops[kops], short for Kubernetes Operations, is a set of tools for installing, operating, and deleting Kubernetes clusters. kops can also perform rolling upgrades from older versions of Kubernetes to newer ones. kops also manages the cluster add-ons. After the cluster is created, the usual link:getting-started[kubectl CLI] can be used to manage resources in the cluster.
+https://github.com/kubernetes/kops[kops], short for Kubernetes Operations, is a set of tools for installing, operating, and deleting Kubernetes clusters. kops can also perform rolling upgrades from older versions of Kubernetes to newer ones. kops also manages the cluster add-ons. After the cluster is created, the link:https://kubernetes.io/docs/tasks/tools/install-kubectl/[Kubernetes CLI] can be used to manage resources in the cluster. If you have not installed the Kubernetes CLI before, please do so now before continuing.
 
 kops is available on Mac OSX, Linux, or the Windows 10 Linux Subsystem. 
 
@@ -15,7 +15,7 @@ There is no need to download a Kubernetes binary distribution for creating a clu
 
 At this point brew PR https://github.com/Homebrew/homebrew-core/pull/21305 is not merged, so in order to use kops 1.8 please execute the following command.
 
-    $ curl -LO https://github.com/kubernetes/kops/releases/download/$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)/kops-darwin-amd64
+    $ curl -LO https://github.com/kubernetes/kops/releases/download/1.8.0/kops-darwin-amd64
     $ chmod +x kops-darwin-amd64
     $ sudo mv kops-darwin-amd64 /usr/local/bin/kops
 

--- a/local-development/readme.adoc
+++ b/local-development/readme.adoc
@@ -62,13 +62,6 @@ Finally delete the previous minikube ISO:
 
     minikube delete
 +
-. Install Kubectl CLI
-
-    $ brew install kubernetes-cli
-+
-If you already have Kubectl CLI installed, then you just need to update it:
-+
-    $ brew upgrade kubernetes-cli
 
 === Setup on Windows
 
@@ -99,11 +92,6 @@ Verify the version:
     $ minikube version
     minikube version: v0.24.1
 +
-. Install or Upgrade Kubectl CLI:
-+
-    $ curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
-    $ chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-
 
 === Setup on EC2 (if you do not virtualbox on your laptop)
 

--- a/prereqs.adoc
+++ b/prereqs.adoc
@@ -13,9 +13,9 @@ An error occurred (OptInRequired) when calling the DescribeAvailabilityZones ope
 ```
 NOTE: You will incur charges as you go through these workshop guides as it will exceed the link:http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/free-tier-limits.html[limits of AWS free tier]. An estimate of charges (<$20/day) can be seen at this link:https://calculator.s3.amazonaws.com/index.html#r=FRA&s=EC2&key=calc-E6DBD6F1-C45D-4827-93F8-D9B18C5994B0[simple monthly calculator].
 
-== AWS CLI
+== AWS CLI and Kubernetes CLI
 
-Install the latest version of http://docs.aws.amazon.com/cli/latest/userguide/awscli-install-bundle.html[AWS CLI] on your machine.
+Install the latest version of the link:http://docs.aws.amazon.com/cli/latest/userguide/awscli-install-bundle.html[AWS CLI] and the link:https://kubernetes.io/docs/tasks/tools/install-kubectl/[Kubernetes CLI] on your machine.
 
 === Setup on macOS
 
@@ -29,6 +29,14 @@ Provision and install AWS CLI on a Mac OS via https://brew.sh/[homebrew].
 
     brew install awscli
 
+. Install Kubectl CLI
+
+    $ brew install kubernetes-cli
++
+If you already have Kubectl CLI installed, then you just need to update it:
++
+    $ brew upgrade kubernetes-cli    
+
 === Setup on Windows
 
 The Windows 10 Linux subsystem is required if you are using Windows 10.
@@ -41,7 +49,13 @@ The lab has been tested with Windows 10. A similar Unix shell on other Windows m
 
 === Setup on Linux
 
-. http://docs.aws.amazon.com/cli/latest/userguide/awscli-install-linux.html
+. Install the AWS CLI
++ Follow this document: http://docs.aws.amazon.com/cli/latest/userguide/awscli-install-linux.html
+
+. Install or Upgrade Kubectl CLI:
++
+    $ curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+    $ chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 
 == AWS IAM Permissions
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Fix cURL link for kops 1.8.0; Fix kubectl install link

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
