### PR TITLE
fixed jsonpath of "get pod memory" example command

### DIFF
--- a/developer-concepts/readme.adoc
+++ b/developer-concepts/readme.adoc
@@ -84,7 +84,7 @@ CPU can be requested in _cpu units_. 1 cpu unit is equivalent 1 AWS vCPU. It can
 
 By default, a container in a pod is allocated no memory request/limit and 100m CPU request and no limit. This can be verified using the previously started pod:
 
-	$ kubectl get pod/nginx-pod -o jsonpath={.spec.containers[].resources}
+	$ kubectl get pod/nginx-pod -o jsonpath={.spec.containers..resources}
 	map[requests:map[cpu:100m]]
 
 ===== Assign memory and CPU


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Found a bug in an example command

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
