### PR TITLE
fixed example commands

### DIFF
--- a/developer-concepts/readme.adoc
+++ b/developer-concepts/readme.adoc
@@ -84,7 +84,7 @@ CPU can be requested in _cpu units_. 1 cpu unit is equivalent 1 AWS vCPU. It can
 
 By default, a container in a pod is allocated no memory request/limit and 100m CPU request and no limit. This can be verified using the previously started pod:
 
-	$ kubectl get pod/nginx-pod -o jsonpath={.spec.containers[].resources}
+	$ kubectl get pod/nginx-pod -o jsonpath={.spec.containers..resources}
 	map[requests:map[cpu:100m]]
 
 ===== Assign memory and CPU
@@ -120,7 +120,7 @@ Create the pod:
 
 Get more details about the requests and limits:
 
-	$ kubectl get pod/nginx-pod2 -o jsonpath={.spec.containers[].resources}
+	$ kubectl get pod/nginx-pod2 -o jsonpath={.spec.containers..resources}
 	map[limits:map[memory:200Mi cpu:2] requests:map[cpu:1 memory:100Mi]]
 
 NGINX container requires fairly low memory and CPU. And so these request and limit numbers would work well, and the pod is started correctly. Now, let's try to start a WildFly pod using similar numbers. The configuration file for the same is shown:
@@ -183,7 +183,7 @@ Now, the Pod successfully starts.
 
 Get more details about the resources allocated to the Pod:
 
-	$ kubectl get pod/wildfly-pod -o jsonpath={.spec.containers[].resources}
+	$ kubectl get pod/wildfly-pod -o jsonpath={.spec.containers..resources}
 	map[limits:map[cpu:2 memory:300Mi] requests:map[cpu:1 memory:100Mi]]
 
 === Quality of service
@@ -236,7 +236,7 @@ Create this Pod:
 
 Check the resources:
 
-	$ kubectl get pod/nginx-pod-guaranteed -o jsonpath={.spec.containers[].resources}
+	$ kubectl get pod/nginx-pod-guaranteed -o jsonpath={.spec.containers..resources}
 	map[limits:map[cpu:1 memory:200Mi] requests:map[cpu:1 memory:200Mi]]
 
 Check the QoS:
@@ -273,7 +273,7 @@ Create this Pod:
 
 Check the resources:
 
-	$ kubectl get pod/nginx-pod-guaranteed2 -o jsonpath={.spec.containers[].resources}
+	$ kubectl get pod/nginx-pod-guaranteed2 -o jsonpath={.spec.containers..resources}
 	map[limits:map[cpu:1 memory:200Mi] requests:map[cpu:1 memory:200Mi]]
 
 Check the QoS:
@@ -314,7 +314,7 @@ Create this Pod:
 
 Check the resources:
 
-	$ kubectl get pod/nginx-pod-burstable -o jsonpath={.spec.containers[].resources}
+	$ kubectl get pod/nginx-pod-burstable -o jsonpath={.spec.containers..resources}
 	map[limits:map[cpu:1 memory:200Mi] requests:map[cpu:1 memory:100Mi]]
 
 Check the QoS:


### PR DESCRIPTION
fixed more array routes for jsonpath of example commands

*Issue #, if available:*

*Description of changes:*
fixed more array routes for jsonpath of example commands


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
