### PR TITLE
Expose port 5000.

### DIFF
--- a/app-tracing/x-ray/readme.adoc
+++ b/app-tracing/x-ray/readme.adoc
@@ -86,7 +86,7 @@ Replace line 14 and change *image: <AWS::AccountId>.dkr.ecr.<AWS::Region>.amazon
 
 .  Test the docker image locally, you should get a reply when you `curl http://0.0.0.0:5000` : 
 
-	$ docker run -it <AWS::AccountId>.dkr.ecr.<AWS::Region>.amazonaws.com/flaskxray:v1
+	$ docker run -p 5000:5000 -it <AWS::AccountId>.dkr.ecr.<AWS::Region>.amazonaws.com/flaskxray:v1
 
  		Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)
 


### PR DESCRIPTION
Expose port 5000 to enable run curl http://0.0.0.0:5000 as the example.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
