### PR TITLE
Treat region as a variable, like account-id in config-secrets

### DIFF
--- a/config-secrets/readme.adoc
+++ b/config-secrets/readme.adoc
@@ -584,8 +584,8 @@ and click it. In the Permissions tab, expand the inline policy for `nodes.exampl
                     "ssm:GetParameter"
                 ],
                 "Resource": [
-                    "arn:aws:ssm:us-east-1:<account-id>:parameter/GREETING",
-                    "arn:aws:ssm:us-east-1:<account-id>:parameter/NAME"
+                    "arn:aws:ssm:<region>:<account-id>:parameter/GREETING",
+                    "arn:aws:ssm:<region>:<account-id>:parameter/NAME"
                 ]
             }
         ]
@@ -601,7 +601,7 @@ Only the value of the secure string parameter is encrypted. The name of the para
     --name GREETING \
     --value Hello \
     --type SecureString \
-    --key-id arn:aws:kms:us-east-1:<account-id>:key/414a963b-7fe4-4a61-b19f-ea408b9bda3b
+    --key-id arn:aws:kms:<region>:<account-id>:key/414a963b-7fe4-4a61-b19f-ea408b9bda3b
   {
       "Version": 1
   }
@@ -642,7 +642,7 @@ By default, the encrypted value of the secret is shown in the output.
     --name NAME \
     --value World \
     --type SecureString \
-    --key-id arn:aws:kms:us-east-1:<account-id>:key/414a963b-7fe4-4a61-b19f-ea408b9bda3b
+    --key-id arn:aws:kms:<region>:<account-id>:key/414a963b-7fe4-4a61-b19f-ea408b9bda3b
   {
       "Version": 1
   }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
I ran into a little issue with using the IAM rule and secret creation as presented because my cluster was running in us-west-1 and not us-east-1 as was hardcoded here.

I did not see a specific region set in the pre-requisites, so this PR changes `us-east-1` in relevant policies and commands to be a variable (`<region>`), similar to how `<account-id>` is currently handled to help other folks running through this (excellent!) guide to ensure they put the region that's relevant for them in the command and policy.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
