### PR TITLE
cloud labels can be added to an existing cluster

### DIFF
--- a/ingress-controllers/readme.adoc
+++ b/ingress-controllers/readme.adoc
@@ -238,10 +238,10 @@ being run. If you are running BSD or MacOS you can use `gsed`.
 We need to have cloud labels enabled for this ingress controller to work.
 You have 2 options, skip the section which does not fit in your case:
 
-1. create a new cluster
-2. modify an existing cluster
+1. <<Create a New Cluster>>
+2. <<Modify an Existing Cluster>>
 
-=== Create kops cluster with cloud labels
+=== Create a New Cluster
 
 Cloud Labels are required to make Kube AWS Ingress Controller work,
 because it has to find the AWS Application Load Balancers it manages
@@ -256,15 +256,15 @@ your S3 Bucket name for kops configuration and you kops cluster name:
         export KOPS_CLUSTER_NAME=example.cluster.k8s.local
 
 
-The you create the kops cluster and validate that everything is set up properly.
+Then you create the kops cluster and validate that everything is set up properly.
 
         export KOPS_STATE_STORE=s3://${S3_BUCKET}
         kops create cluster --name $KOPS_CLUSTER_NAME --zones $AWS_AVAILABILITY_ZONES --cloud-labels kubernetes.io/cluster/$KOPS_CLUSTER_NAME=owned --yes
         kops validate cluster
 
-=== Modify and existing cluster add cloud labels
+=== Modify an Existing Cluster
 
-Next, you modify your existing Kops cluster and update it.
+To modify your existing kops cluster and update it.
 
         export KOPS_STATE_STORE=s3://${S3_BUCKET}
         kops edit cluster $KOPS_CLUSTER_NAME

--- a/ingress-controllers/readme.adoc
+++ b/ingress-controllers/readme.adoc
@@ -235,6 +235,12 @@ For this tutorial I assume you have GNU sed installed, if not read
 commands with `sed` to modify the files according to the `sed` command
 being run. If you are running BSD or MacOS you can use `gsed`.
 
+We need to have cloud labels enabled for this ingress controller to work.
+You have 2 options, skip the section which does not fit in your case:
+
+1. create a new cluster
+2. modify an existing cluster
+
 === Create kops cluster with cloud labels
 
 Cloud Labels are required to make Kube AWS Ingress Controller work,
@@ -252,10 +258,28 @@ your S3 Bucket name for kops configuration and you kops cluster name:
 
 The you create the kops cluster and validate that everything is set up properly.
 
-
         export KOPS_STATE_STORE=s3://${S3_BUCKET}
         kops create cluster --name $KOPS_CLUSTER_NAME --zones $AWS_AVAILABILITY_ZONES --cloud-labels kubernetes.io/cluster/$KOPS_CLUSTER_NAME=owned --yes
         kops validate cluster
+
+=== Modify and existing cluster add cloud labels
+
+Next, you modify your existing Kops cluster and update it.
+
+        export KOPS_STATE_STORE=s3://${S3_BUCKET}
+        kops edit cluster $KOPS_CLUSTER_NAME
+
+Add cloudLabels dependent on your $KOPS_CLUSTER_NAME, for example example.cluster.k8s.local:
+
+```
+ spec:
+   cloudLabels:
+     kubernetes.io/cluster/example.cluster.k8s.local: owned
+```
+
+Update the cluster with the new configuration:
+
+       kops update cluster $KOPS_CLUSTER_NAME --yes
 
 
 === IAM role


### PR DESCRIPTION
This adds a section in case of a user wants to modify an existing cluster instead of creating a new one.