### PR TITLE
updated name of deployment to match documentation

### DIFF
--- a/developer-concepts/templates/deployment.yaml
+++ b/developer-concepts/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: nginx-deployment-ns
+  name: nginx-deployment
 spec:
   replicas: 3 
   template:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/aws-workshop-for-kubernetes/issues/310

*Description of changes:*
The documentation did not match what was created using the developer-concepts/templates/deployment.yaml configuration file.  I created an update to make the configuration file match what the instructions indicate.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
