### PR TITLE
Add section on admission policies

### DIFF
--- a/admission-policy/readme.adoc
+++ b/admission-policy/readme.adoc
@@ -289,7 +289,7 @@ To verify that your policy is working, create separate test Pods in the `product
 
 ```yaml
 kind: Pod
-version: v1
+apiVersion: v1
 metadata:
   name: nginx
   labels:
@@ -304,7 +304,7 @@ spec:
 
 ```yaml
 kind: Pod
-version: v1
+apiVersion: v1
 metadata:
   name: amazon-linux-pod
   labels:

--- a/admission-policy/readme.adoc
+++ b/admission-policy/readme.adoc
@@ -5,15 +5,17 @@ v1.0, 2018-01-17
 
 Kubernetes https://kubernetes.io/docs/admin/admission-controllers/[Admission Controllers]
 perform *semantic validation* of resources during create, update, and delete operations.
-In Kubernetes 1.8+, you can use OPA to enforce custom policies without recompiling or reconfiguring
+In Kubernetes 1.8+, you can use http://www.openpolicyagent.org/[The Open Policy Agent] to enforce custom policies without recompiling or reconfiguring
 the Kubernetes API server by leveraging
 https://kubernetes.io/docs/admin/extensible-admission-controllers/#external-admission-webhooks[External Admission Webhooks].
+The Open Policy Agent is a general-purpose policy engine that aims to policy-enable
+other projects or services which is integrated either as a library or as a side-car.
 
-For example, you could enforce any of the following policies:
+For example, using OPA with Kubernetes you could enforce any of the following policies:
 
 * All images come from an AWS repository (other than a whitelist)
 * Images are pulled from the same AWS repository in the same region as the cluster
-* Namespaces are assigned to different AWS IAM groups
+* Each namespace is controlled by the users in different AWS IAM groups
 
 
 == Goals
@@ -337,7 +339,7 @@ spec:
     name: amazon-linux
 ```
 
-Create a 'production' namespace.
+Create a `production` namespace.
 ```bash
 kubectl create namespace production
 ```

--- a/admission-policy/readme.adoc
+++ b/admission-policy/readme.adoc
@@ -3,13 +3,19 @@
 Doc Writer <tim@styra.com>
 v1.0, 2018-01-17
 
+
 Kubernetes https://kubernetes.io/docs/admin/admission-controllers/[Admission Controllers]
 perform *semantic validation* of resources during create, update, and delete operations.
-In Kubernetes 1.8+, you can use http://www.openpolicyagent.org/[The Open Policy Agent] to enforce custom policies without recompiling or reconfiguring
-the Kubernetes API server by leveraging
-https://kubernetes.io/docs/admin/extensible-admission-controllers/#external-admission-webhooks[External Admission Webhooks].
+In Kubernetes 1.8+, you can use the http://www.openpolicyagent.org/[Open Policy Agent] and
+https://kubernetes.io/docs/admin/extensible-admission-controllers/#external-admission-webhooks[Kubernetes External Admission Webhooks]
+to enforce custom admission control policies without recompiling or reconfiguring
+the Kubernetes API server.
+
 The Open Policy Agent is a general-purpose policy engine that aims to policy-enable
-other projects or services which is integrated either as a library or as a side-car.
+other projects or services.  It provides a rich, declarative policy language
+where policy decisions may be booleans (e.g. allow/deny), strings (e.g. hostnames),
+numbers (e.g. ratelimits), arrays (e.g. destination hosts for a pod), or dictionaries
+(e.g. JSON patch changes to a pod definition).
 
 For example, using OPA with Kubernetes you could enforce any of the following policies:
 
@@ -34,17 +40,19 @@ Keep in mind that External Admission Webhook support in Kubernetes is currently 
 
 . Create the Kubernetes cluster with `kops` and enable the External Admission Webhooks
 . Install the OpenPolicyAgent as an External Admission Webhook
-. Write admission control policies with OPA
+. Write admission control policies with the OpenPolicyAgent
 
 == Step 1: Create Cluster with External Admission Controllers via `kops`
 
 Create a Kubernetes 1.8 cluster with `kops` as shown in the
 link:../cluster-install/readme.adoc[Cluster Install] instructions.
 
-Update the Cluster spec to enable webhooks.
-Remember that the cluster is named `example.cluster.k8s.local`.
+Update the Cluster spec to enable webhooks. (Remember that when you set up
+  the cluster you chose the name `example.cluster.k8s.local`. )
 
-Run `kops edit example.cluster.k8s.local` and specify:
+```bash
+kops edit example.cluster.k8s.local
+```
 
 ```yaml
   kubeAPIServer:
@@ -55,8 +63,7 @@ Run `kops edit example.cluster.k8s.local` and specify:
       - PersistentVolumeLabel
       - DefaultStorageClass
       - DefaultTolerationSeconds
-      - MutatingAdmissionWebhook
-      - ValidatingAdmissionWebhook
+      - GenericAdmissionWebhook
       - ResourceQuota
     runtimeConfig:
       admissionregistration.k8s.io/v1alpha1: "true"
@@ -72,7 +79,9 @@ kops update example.cluster.k8s.local --yes
 
 === 2.1 Generate service-certificate for OPA
 
-First, create the required OpenSSL configuration files:
+First, create the required OpenSSL configuration files.  Put these in your current
+directory; we will only use them once to generate certificates.  You may discard
+them after running the `openssl` commands below.
 
 *client.conf*
 ```bash
@@ -109,21 +118,44 @@ IMPORTANT: The subjectAltName/IP address in the certificate MUST match the one c
 Now create local files that contain the CA and client/server key pairs.  Shortly we will
 hand these keys to OPA and the API server so they can communicate.
 
+Create a certificate authority:
+
 ```bash
-# Create a certificate authority
 openssl genrsa -out ca.key 2048
+```
+
+```bash
 openssl req -x509 -new -nodes -key ca.key -days 100000 -out ca.crt -subj "/CN=admission_ca"
+```
 
-# Create a server certiticate
+Create a server certiticate:
+
+```bash
 openssl genrsa -out server.key 2048
-openssl req -new -key server.key -out server.csr -subj "/CN=admission_server" -config server.conf
-openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 100000 -extensions v3_req -extfile server.conf
+```
 
-# Create a client certiticate
+```bash
+openssl req -new -key server.key -out server.csr -subj "/CN=admission_server" -config server.conf
+```
+
+```bash
+openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 100000 -extensions v3_req -extfile server.conf
+```
+
+Create a client certiticate:
+
+```bash
 openssl genrsa -out client.key 2048
+```
+
+```bash
 openssl req -new -key client.key -out client.csr -subj "/CN=admission_client" -config client.conf
+```
+
+```bash
 openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out client.crt -days 100000 -extensions v3_req -extfile client.conf
 ```
+
 
 === 2.2: Deploy OPA on Kubernetes
 
@@ -165,10 +197,10 @@ kubectl create secret tls opa-server --cert=server.crt --key=server.key -n opa
 ```
 
 Finally, create the Deployment to run OPA as an Admission Controller.
-The deployment contains two containers: OPA and kube-mgmt.  kube-mgmt
-is a sidecar that helps OPA interact with kubernetes.  OPA by itself
-is a general-purpose policy engine and knows nothing about kubernetes,
-so kube-mgmt fills the gap.
+The deployment contains two containers: `opa` and `kube-mgmt`.  `opa` by
+itself is a general-purpose policy engine and knows nothing about Kubernetes.
+kube-mgmt is a collection of Kubernetes-specific code that helps
+OPA interact with kubernetes.
 
 **opa-admission-controller-deployment.yaml**:
 
@@ -253,7 +285,7 @@ kubectl logs -l app=opa -c opa -n opa
 === 3.1 Load a policy into OPA
 To test admission control, create a policy that requires all images
 to come from an AWS repository.  For details on the policy language, see the
-http://www.openpolicyagent.org/docs/(Open Policy Agent) documentation.
+http://www.openpolicyagent.org/docs/[Open Policy Agent] documentation.
 
 **image_source.rego**:
 
@@ -272,9 +304,8 @@ deny[explanation] {
 
 # main is entry point to policy.
 # Boilerplate required by admission webhook.
-# Policy decision is `status`, which is either
-#   {"allowed": true} or
-#   {"allowed": false, "status": {"reason": <string>}}
+# Actual policy decision is `status`, which takes the form
+#   {"allowed": BOOLEAN, "status": {"reason": STRING}}
 main = {
     "apiVersion": "admission.k8s.io/v1alpha1",
     "kind": "AdmissionReview",
@@ -282,7 +313,7 @@ main = {
 }
 
 # Boilerplate: construct 'reason' and 'allowed' variables.
-#  Real policy is collection of 'deny' statements.
+#  Real policy is the collection of 'deny' statements above.
 #  If not denied, allow.
 reason = msg {
     msg = concat(", ", deny)
@@ -303,7 +334,7 @@ policy into OPA.
 
 === 3.2 Check that the policy is working
 
-To verify that your policy is working, create separate test Pods in the `production` namespace.
+To verify that your policy is working, create separate test pods in the `production` namespace.
 
 **nginx-pod.yaml**:
 
@@ -349,20 +380,19 @@ Verify that you can create an amazon-linux pod.
 kubectl -n production create -f amazon-linux-pod.yaml
 ```
 
-Verify that you CANNOT create an nginx pod.
+Verify that you CANNOT create an nginx pod and receive the appropriate error message.
 ```bash
 kubectl -n production create -f nginx-pod.yaml
 ```
-
-You will get an error message:
 ```bash
 Error from server (image 'nginx' not from AWS ECR): error when creating "nginx-pod.yaml":
 ```
 
-You might have a collection of images like `nginx` that
-don't need to come from an AWS repository.  In that case, you can
+This example shows how to ensure ALL images comes from an AWS repository.
+But in reality you might have a collection of images like `nginx` that
+can come from outside of AWS.  In that case, you can
 add a whitelist to the OPA policy and modify the `deny` statement accordingly.
-
+Just update the ConfigMap, and `kube-mgmt` will update OPA with your new policy.
 
 == Wrap Up
 

--- a/admission-policy/readme.adoc
+++ b/admission-policy/readme.adoc
@@ -1,0 +1,342 @@
+
+= Admission Control for Kubernetes on AWS
+Doc Writer <tim@styra.com>
+v1.0, 2018-01-17
+
+Kubernetes https://kubernetes.io/docs/admin/admission-controllers/[Admission Controllers]
+perform *semantic validation* of resources during create, update, and delete operations.
+In Kubernetes 1.7+, you can use OPA to enforce custom policies without recompiling or reconfiguring
+the Kubernetes API server by leveraging
+https://kubernetes.io/docs/admin/extensible-admission-controllers/#external-admission-webhooks[External Admission Webhooks].
+
+For example, you could enforce any of the following policies:
+
+* All images come from an AWS repository (other than a whitelist)
+* Images are pulled from the same AWS repository in the same region as the cluster
+* Namespaces are assigned to different AWS IAM groups
+
+
+== Goals
+
+This tutorial shows how to use OPA to enforce custom policies on resources in
+Kubernetes running on AWS. For the purpose of this tutorial, you will define a policy that
+prevents users from running `kubectl exec` on "privileged" containers in the
+"production" namespace.
+
+
+== Prerequisites
+
+This tutorial requires a Kubernetes 1.7 (or later) cluster. To test Kubernetes locally,
+we recommend using [minikube](https://kubernetes.io/docs/getting-started-guides/minikube/).
+Keep in mind that External Admission Webhook support in Kubernetes is currently in **alpha**.
+
+== Overview
+
+1. Create the Kubernetes cluster with `kops` and enable the External Admission Webhooks
+2. Install the OpenPolicyAgent as an External Admission Webhook
+3. Write admission control policies with OPA
+
+
+
+== Step 1: Create Cluster with External Admission Controllers via `kops`
+
+Create a Kubernetes 1.9 cluster with `kops` using the usual commands:
+
+
+```bash
+kops create cluster ...
+kops create secret ...
+```
+
+Update the Cluster spec to enable webhooks and configure client credentials.
+
+Run `kops edit <cluster-name>` and specify:
+
+```yaml
+  kubeAPIServer:
+    admissionControl:
+      - NamespaceLifecycle
+      - LimitRanger
+      - ServiceAccount
+      - PersistentVolumeLabel
+      - DefaultStorageClass
+      - DefaultTolerationSeconds
+      - GenericAdmissionWebhook
+      - ResourceQuota
+    runtimeConfig:
+      admissionregistration.k8s.io/v1alpha1: "true"
+```
+
+Then update `kops`.
+```bash
+kops update <clustername>
+```
+
+
+== Step 2: Deploy OPA on Kubernetes
+
+=== 2.1 Generate service-certificate for OPA
+
+First, create the required OpenSSL configuration files:
+
+*server.conf*
+```bash
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth, serverAuth
+```
+
+Now generate the CA and server key pair.
+
+```bash
+# Create a certificate authority
+openssl genrsa -out ca.key 2048
+openssl req -x509 -new -nodes -key ca.key -days 100000 -out ca.crt -subj "/CN=admission_ca"
+
+# Create a server certiticate
+# IMPORTANT: the CN must match the name of the service used to expose the external admission controller.
+openssl genrsa -out server.key 2048
+openssl req -new -key server.key -out server.csr -subj "/CN=opa.opa.svc" -config server.conf
+openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 100000 -extensions v3_req -extfile server.conf
+```
+
+=== 2.2: Deploy OPA on Kubernetes
+
+First, create a namespace to deploy OPA into.
+
+```bash
+kubectl create namespace opa
+```
+
+Create a Service to expose the OPA API. The Kubernetes API server will lookup
+the Service and execute webhook requests against it.
+
+**opa-admission-controller-service.yaml**:
+
+```yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: opa
+spec:
+  selector:
+    app: opa
+  ports:
+  - name: https
+    protocol: TCP
+    port: 443
+    targetPort: 443
+```
+
+```bash
+kubectl create -f opa-admission-controller-service.yaml -n opa
+```
+
+Next, create Secrets containing the TLS credentials for OPA:
+
+```bash
+kubectl create secret generic opa-ca --from-file=ca.crt -n opa
+kubectl create secret tls opa-server --cert=server.crt --key=server.key -n opa
+```
+
+Finally, create the Deployment to run OPA as an Admission Controller.
+
+**opa-admission-controller-deployment.yaml**:
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: opa
+  name: opa
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: opa
+      name: opa
+    spec:
+      containers:
+        - name: opa
+          image: openpolicyagent/opa:0.5.13
+          args:
+            - "run"
+            - "--server"
+            - "--tls-cert-file=/certs/tls.crt"
+            - "--tls-private-key-file=/certs/tls.key"
+            - "--addr=0.0.0.0:443"
+            - "--insecure-addr=127.0.0.1:8181"
+          volumeMounts:
+            - readOnly: true
+              mountPath: /certs
+              name: opa-server
+        - name: kube-mgmt
+          image: openpolicyagent/kube-mgmt:0.5
+          args:
+            - "--replicate=v1/pods"
+            - "--pod-name=$(MY_POD_NAME)"
+            - "--pod-namespace=$(MY_POD_NAMESPACE)"
+            - "--register-admission-controller"
+            - "--admission-controller-ca-cert-file=/certs/ca.crt"
+            - "--admission-controller-service-name=opa"
+            - "--admission-controller-service-namespace=$(MY_POD_NAMESPACE)"
+          volumeMounts:
+            - readOnly: true
+              mountPath: /certs
+              name: opa-ca
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+      volumes:
+        - name: opa-server
+          secret:
+            secretName: opa-server
+        - name: opa-ca
+          secret:
+            secretName: opa-ca
+```
+
+```bash
+kubectl create -f opa-admission-controller-deployment.yaml -n opa
+```
+
+When OPA starts, the sidecar (`kube-mgmt`) will register it as an External
+Admission Controller. To verify that registration succeeded, run `kubectl proxy`
+in another terminal and then query the Kubernetes API for the list of External
+Admission Controllers.
+
+```bash
+curl localhost:8001/apis/admissionregistration.k8s.io/v1alpha1/externaladmissionhookconfigurations
+```
+
+Finally, you can follow the OPA logs to see the webhook requests being issued
+by the Kubernetes API server:
+
+```
+kubectl logs -l app=opa -c opa -n opa
+```
+
+== Step 3:  Enforce Kubernetes Admission Control with OPA
+
+=== 3.1 Load a policy into OPA
+To test admission control, create a policy that restricts exec access on
+privileged pods:
+
+**image_source.rego**:
+
+```ruby
+package system
+
+# Deny requests that include container images not from ECR.
+deny[explanation] {
+    image_name = input.spec.object.Spec.Containers[_].Image
+    image_name_parts = split(image_name, "/")
+    repo_name = image_name_parts[0]
+    not startswith(repo_name, "12345678.dkr.ecr.us-west-2.amazonaws.com")
+    explanation = sprintf("image '%v' not from AWS ECR", [image_name])
+}
+
+
+# main is entry point to policy.
+# Boilerplate required by admission webhook.
+# Policy decision is `status`, which is either
+#   {"allowed": true} or
+#   {"allowed": false, "status": {"reason": <string>}}
+main = {
+    "apiVersion": "admission.k8s.io/v1alpha1",
+    "kind": "AdmissionReview",
+    "status": {"allowed": allowed, "status": {"reason": reason}}
+}
+
+# Boilerplate: construct 'reason' and 'allowed' variables.
+#  Real policy is collection of 'deny' statements.
+#  If not denied, allow.
+reason = msg {
+    msg = concat(", ", deny)
+}
+default allowed = true
+allowed = false { n = count(deny); n > 0 }
+
+```
+
+Store the policy in Kubernetes as a ConfigMap.
+
+```bash
+kubectl create configmap privileged-exec --from-file=image_source.rego -n opa
+```
+
+The OPA sidecar will notice the ConfigMap and automatically load the contained
+policy into OPA.
+
+=== 3.2 Check that the policy is working
+
+To verify that your policy is working, create separate test Pods in the `production` namespace.
+
+**nginx-pod.yaml**:
+
+```yaml
+kind: Pod
+version: v1
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  containers:
+  - image: nginx
+    name: nginx
+```
+
+**amazon-linux-pod.yaml**:
+
+```yaml
+kind: Pod
+version: v1
+metadata:
+  name: amazon-linux-pod
+  labels:
+    app: amazon-linux
+spec:
+  containers:
+  - image: 12345678.dkr.ecr.us-west-2.amazonaws.com/amazon-linux
+    name: amazon-linux
+```
+
+Create a 'production' namespace.
+```bash
+kubectl create namespace production
+```
+
+Verify that you can create an amazon-linux pod.
+```bash
+kubectl -n production create -f amazon-linux-pod.yaml
+```
+
+Verify that you CANNOT create an nginx pod.
+```bash
+kubectl -n production create -f nginx-pod.yaml
+```
+
+
+== Wrap Up
+
+Congratulations for finishing the tutorial!
+
+This tutorial showed how you can leverage OPA to enforce admission control
+decisions in Kubernetes clusters without modifying or recompiling any
+Kubernetes components. Furthermore, once Kubernetes is configured to use OPA as
+an External Admission Controller, policies can be modified on-the-fly to
+satisfy changing operational requirements.

--- a/admission-policy/readme.adoc
+++ b/admission-policy/readme.adoc
@@ -199,7 +199,7 @@ kubectl create secret tls opa-server --cert=server.crt --key=server.key -n opa
 Finally, create the Deployment to run OPA as an Admission Controller.
 The deployment contains two containers: `opa` and `kube-mgmt`.  `opa` by
 itself is a general-purpose policy engine and knows nothing about Kubernetes.
-kube-mgmt is a collection of Kubernetes-specific code that helps
+`kube-mgmt` is a collection of Kubernetes-specific code that helps
 OPA interact with kubernetes.
 
 **opa-admission-controller-deployment.yaml**:
@@ -287,6 +287,12 @@ To test admission control, create a policy that requires all images
 to come from an AWS repository.  For details on the policy language, see the
 http://www.openpolicyagent.org/docs/[Open Policy Agent] documentation.
 
+NOTE: Below replace the Amazon account ID 123456789 with your own account if your
+want the pod to actually come up.  If you just want to see the admission
+controller in action, you can leave it with the fake ID.  That account ID
+also appears in the image names when you create pods below; just make sure
+the account IDs are the same.
+
 **image_source.rego**:
 
 ```ruby
@@ -334,7 +340,7 @@ policy into OPA.
 
 === 3.2 Check that the policy is working
 
-To verify that your policy is working, create separate test pods in the `production` namespace.
+To verify that your policy is working, create separate test pods.
 
 **nginx-pod.yaml**:
 
@@ -370,29 +376,26 @@ spec:
     name: amazon-linux
 ```
 
-Create a `production` namespace.
-```bash
-kubectl create namespace production
-```
-
 Verify that you can create an amazon-linux pod.
 ```bash
-kubectl -n production create -f amazon-linux-pod.yaml
+kubectl create -f amazon-linux-pod.yaml
 ```
 
 Verify that you CANNOT create an nginx pod and receive the appropriate error message.
 ```bash
-kubectl -n production create -f nginx-pod.yaml
+kubectl create -f nginx-pod.yaml
 ```
 ```bash
 Error from server (image 'nginx' not from AWS ECR): error when creating "nginx-pod.yaml":
 ```
 
-This example shows how to ensure ALL images comes from an AWS repository.
+This example shows how to ensure ALL images come from an AWS repository.
 But in reality you might have a collection of images like `nginx` that
-can come from outside of AWS.  In that case, you can
-add a whitelist to the OPA policy and modify the `deny` statement accordingly.
-Just update the ConfigMap, and `kube-mgmt` will update OPA with your new policy.
+can come from outside of AWS.  Or maybe you only want to apply the policy
+to certain Kubernetes namespaces.  OPA's policy language is flexible enough
+to add image whitelists and control the applicable namespaces.
+Just modify your policy locally, update the ConfigMap, and `kube-mgmt` will
+update OPA with your changes.
 
 == Wrap Up
 

--- a/admission-policy/readme.adoc
+++ b/admission-policy/readme.adoc
@@ -5,7 +5,7 @@ v1.0, 2018-01-17
 
 Kubernetes https://kubernetes.io/docs/admin/admission-controllers/[Admission Controllers]
 perform *semantic validation* of resources during create, update, and delete operations.
-In Kubernetes 1.7+, you can use OPA to enforce custom policies without recompiling or reconfiguring
+In Kubernetes 1.8+, you can use OPA to enforce custom policies without recompiling or reconfiguring
 the Kubernetes API server by leveraging
 https://kubernetes.io/docs/admin/extensible-admission-controllers/#external-admission-webhooks[External Admission Webhooks].
 
@@ -20,37 +20,29 @@ For example, you could enforce any of the following policies:
 
 This tutorial shows how to use OPA to enforce custom policies on resources in
 Kubernetes running on AWS. For the purpose of this tutorial, you will define a policy that
-prevents users from running `kubectl exec` on "privileged" containers in the
-"production" namespace.
+requires all pod images to come from an AWS image repository.
 
 
 == Prerequisites
 
-This tutorial requires a Kubernetes 1.7 (or later) cluster. To test Kubernetes locally,
-we recommend using [minikube](https://kubernetes.io/docs/getting-started-guides/minikube/).
+This tutorial requires a Kubernetes 1.8 cluster.
 Keep in mind that External Admission Webhook support in Kubernetes is currently in **alpha**.
 
 == Overview
 
-1. Create the Kubernetes cluster with `kops` and enable the External Admission Webhooks
-2. Install the OpenPolicyAgent as an External Admission Webhook
-3. Write admission control policies with OPA
-
-
+. Create the Kubernetes cluster with `kops` and enable the External Admission Webhooks
+. Install the OpenPolicyAgent as an External Admission Webhook
+. Write admission control policies with OPA
 
 == Step 1: Create Cluster with External Admission Controllers via `kops`
 
-Create a Kubernetes 1.9 cluster with `kops` using the usual commands:
+Create a Kubernetes 1.8 cluster with `kops` as shown in the
+link:../cluster-install/readme.adoc[Cluster Install] instructions.
 
+Update the Cluster spec to enable webhooks.
+Remember that the cluster is named `example.cluster.k8s.local`.
 
-```bash
-kops create cluster ...
-kops create secret ...
-```
-
-Update the Cluster spec to enable webhooks and configure client credentials.
-
-Run `kops edit <cluster-name>` and specify:
+Run `kops edit example.cluster.k8s.local` and specify:
 
 ```yaml
   kubeAPIServer:
@@ -61,7 +53,8 @@ Run `kops edit <cluster-name>` and specify:
       - PersistentVolumeLabel
       - DefaultStorageClass
       - DefaultTolerationSeconds
-      - GenericAdmissionWebhook
+      - MutatingAdmissionWebhook
+      - ValidatingAdmissionWebhook
       - ResourceQuota
     runtimeConfig:
       admissionregistration.k8s.io/v1alpha1: "true"
@@ -69,7 +62,7 @@ Run `kops edit <cluster-name>` and specify:
 
 Then update `kops`.
 ```bash
-kops update <clustername>
+kops update example.cluster.k8s.local --yes
 ```
 
 
@@ -78,6 +71,21 @@ kops update <clustername>
 === 2.1 Generate service-certificate for OPA
 
 First, create the required OpenSSL configuration files:
+
+*client.conf*
+```bash
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth, serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = opa.opa.cluster.svc.local
+```
 
 *server.conf*
 ```bash
@@ -89,9 +97,15 @@ distinguished_name = req_distinguished_name
 basicConstraints = CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 extendedKeyUsage = clientAuth, serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = opa.opa.cluster.svc.local
 ```
 
-Now generate the CA and server key pair.
+IMPORTANT: The subjectAltName/IP address in the certificate MUST match the one configured on the Kubernetes Service.
+
+Now create local files that contain the CA and client/server key pairs.  Shortly we will
+hand these keys to OPA and the API server so they can communicate.
 
 ```bash
 # Create a certificate authority
@@ -99,10 +113,14 @@ openssl genrsa -out ca.key 2048
 openssl req -x509 -new -nodes -key ca.key -days 100000 -out ca.crt -subj "/CN=admission_ca"
 
 # Create a server certiticate
-# IMPORTANT: the CN must match the name of the service used to expose the external admission controller.
 openssl genrsa -out server.key 2048
-openssl req -new -key server.key -out server.csr -subj "/CN=opa.opa.svc" -config server.conf
+openssl req -new -key server.key -out server.csr -subj "/CN=admission_server" -config server.conf
 openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 100000 -extensions v3_req -extfile server.conf
+
+# Create a client certiticate
+openssl genrsa -out client.key 2048
+openssl req -new -key client.key -out client.csr -subj "/CN=admission_client" -config client.conf
+openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out client.crt -days 100000 -extensions v3_req -extfile client.conf
 ```
 
 === 2.2: Deploy OPA on Kubernetes
@@ -145,6 +163,10 @@ kubectl create secret tls opa-server --cert=server.crt --key=server.key -n opa
 ```
 
 Finally, create the Deployment to run OPA as an Admission Controller.
+The deployment contains two containers: OPA and kube-mgmt.  kube-mgmt
+is a sidecar that helps OPA interact with kubernetes.  OPA by itself
+is a general-purpose policy engine and knows nothing about kubernetes,
+so kube-mgmt fills the gap.
 
 **opa-admission-controller-deployment.yaml**:
 
@@ -178,11 +200,9 @@ spec:
               mountPath: /certs
               name: opa-server
         - name: kube-mgmt
-          image: openpolicyagent/kube-mgmt:0.5
+          image: openpolicyagent/kube-mgmt:0.4
           args:
             - "--replicate=v1/pods"
-            - "--pod-name=$(MY_POD_NAME)"
-            - "--pod-namespace=$(MY_POD_NAMESPACE)"
             - "--register-admission-controller"
             - "--admission-controller-ca-cert-file=/certs/ca.crt"
             - "--admission-controller-service-name=opa"
@@ -192,10 +212,6 @@ spec:
               mountPath: /certs
               name: opa-ca
           env:
-            - name: MY_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: MY_POD_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -214,13 +230,14 @@ kubectl create -f opa-admission-controller-deployment.yaml -n opa
 ```
 
 When OPA starts, the sidecar (`kube-mgmt`) will register it as an External
-Admission Controller. To verify that registration succeeded, run `kubectl proxy`
-in another terminal and then query the Kubernetes API for the list of External
-Admission Controllers.
+Admission Controller. To verify that registration succeeded, query
+ the Kubernetes API for the list of External Admission Controllers.
 
 ```bash
-curl localhost:8001/apis/admissionregistration.k8s.io/v1alpha1/externaladmissionhookconfigurations
+kubectl describe externaladmissionhookconfigurations admission.openpolicyagent.org
 ```
+
+
 
 Finally, you can follow the OPA logs to see the webhook requests being issued
 by the Kubernetes API server:
@@ -232,8 +249,9 @@ kubectl logs -l app=opa -c opa -n opa
 == Step 3:  Enforce Kubernetes Admission Control with OPA
 
 === 3.1 Load a policy into OPA
-To test admission control, create a policy that restricts exec access on
-privileged pods:
+To test admission control, create a policy that requires all images
+to come from an AWS repository.  For details on the policy language, see the
+http://www.openpolicyagent.org/docs/(Open Policy Agent) documentation.
 
 **image_source.rego**:
 
@@ -275,7 +293,7 @@ allowed = false { n = count(deny); n > 0 }
 Store the policy in Kubernetes as a ConfigMap.
 
 ```bash
-kubectl create configmap privileged-exec --from-file=image_source.rego -n opa
+kubectl create configmap image-source --from-file=image_source.rego -n opa
 ```
 
 The OPA sidecar will notice the ConfigMap and automatically load the contained
@@ -289,7 +307,7 @@ To verify that your policy is working, create separate test Pods in the `product
 
 ```yaml
 kind: Pod
-apiVersion: v1
+version: v1
 metadata:
   name: nginx
   labels:
@@ -300,18 +318,22 @@ spec:
     name: nginx
 ```
 
+NOTE: Below replace the Amazon account ID 123456789 with your own account if your
+want the pod to actually come up.  If you just want to see the admission
+controller in action, you can leave it with the fake ID.
+
 **amazon-linux-pod.yaml**:
 
 ```yaml
 kind: Pod
-apiVersion: v1
+version: v1
 metadata:
   name: amazon-linux-pod
   labels:
     app: amazon-linux
 spec:
   containers:
-  - image: 12345678.dkr.ecr.us-west-2.amazonaws.com/amazon-linux
+  - image: 123456789.dkr.ecr.us-west-2.amazonaws.com/amazon-linux
     name: amazon-linux
 ```
 
@@ -329,6 +351,15 @@ Verify that you CANNOT create an nginx pod.
 ```bash
 kubectl -n production create -f nginx-pod.yaml
 ```
+
+You will get an error message:
+```bash
+Error from server (image 'nginx' not from AWS ECR): error when creating "nginx-pod.yaml":
+```
+
+You might have a collection of images like `nginx` that
+don't need to come from an AWS repository.  In that case, you can
+add a whitelist to the OPA policy and modify the `deny` statement accordingly.
 
 
 == Wrap Up


### PR DESCRIPTION
Kubernetes admission policies are those enforced when new
resources are created, updated, or deleted.
This tutorial describes admission control and how to impose
organization-specific policies at admission-time, using
the OpenPolicyAgent.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
