### PR TITLE
Fixes to steps around port-forwarding in 103-kubernetes-concepts

### DIFF
--- a/01-path-basics/103-kubernetes-concepts/readme.adoc
+++ b/01-path-basics/103-kubernetes-concepts/readme.adoc
@@ -216,6 +216,7 @@ Verify that the pod came up fine (ensure nothing else is running on port 8088):
 	$ kubectl -n default port-forward $(kubectl -n default get pod -l name=nginx-pod -o jsonpath='{.items[0].metadata.name}') 8088:80
 
 From a new terminal window run:
+
 	$ open http://localhost:8088/
 
 If you are running a Linux distribution that doesn't support `open`, try `xdg-open`, `gnome-open`, or `gvfs-open` instead.  From an AWS Cloud9 environment, use curl instead.

--- a/01-path-basics/103-kubernetes-concepts/readme.adoc
+++ b/01-path-basics/103-kubernetes-concepts/readme.adoc
@@ -217,13 +217,32 @@ Verify that the pod came up fine (ensure nothing else is running on port 8088):
 
 From a new terminal window run:
 
-	$ open http://localhost:8088/
-
-If you are running a Linux distribution that doesn't support `open`, try `xdg-open`, `gnome-open`, or `gvfs-open` instead.  From an AWS Cloud9 environment, use curl instead.
-
-This opens up a browser window and shows the NGINX main page:
-
-image::nginx-pod-default-page.png[]
+	$ curl http://localhost:8088/
+	<!DOCTYPE html>
+	<html>
+	<head>
+	<title>Welcome to nginx!</title>
+	<style>
+	    body {
+	        width: 35em;
+	        margin: 0 auto;
+	        font-family: Tahoma, Verdana, Arial, sans-serif;
+	    }
+	</style>
+	</head>
+	<body>
+	<h1>Welcome to nginx!</h1>
+	<p>If you see this page, the nginx web server is successfully installed and
+	working. Further configuration is required.</p>
+	
+	<p>For online documentation and support please refer to
+	<a href="http://nginx.org/">nginx.org</a>.<br/>
+	Commercial support is available at
+	<a href="http://nginx.com/">nginx.com</a>.</p>
+	
+	<p><em>Thank you for using nginx.</em></p>
+	</body>
+	</html>
 
 If the containers in the pod generate logs, then they can be seen using the command shown:
 

--- a/01-path-basics/103-kubernetes-concepts/readme.adoc
+++ b/01-path-basics/103-kubernetes-concepts/readme.adoc
@@ -214,9 +214,11 @@ Get the list of pod:
 Verify that the pod came up fine (ensure nothing else is running on port 8088):
 
 	$ kubectl -n default port-forward $(kubectl -n default get pod -l name=nginx-pod -o jsonpath='{.items[0].metadata.name}') 8088:80
+
+From a new terminal window run:
 	$ open http://localhost:8088/
 
-If you are running a Linux distribution that doesn't support `open`, try `xdg-open`, `gnome-open`, or `gvfs-open` instead.
+If you are running a Linux distribution that doesn't support `open`, try `xdg-open`, `gnome-open`, or `gvfs-open` instead.  From an AWS Cloud9 environment, use curl instead.
 
 This opens up a browser window and shows the NGINX main page:
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The steps say to run the kubectl port-forward then open the URL from what appears to be the same terminal.  Since the port-forward will block the session, a new terminal session needs to be created to load the URL.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.