### PR TITLE
Fix to kubectl bash-completion

### DIFF
--- a/01-path-basics/101-start-here/readme.adoc
+++ b/01-path-basics/101-start-here/readme.adoc
@@ -77,6 +77,8 @@ image:cloud9-run-script.png[Running the script in Cloud9 Terminal]
 [NOTE]
 All shell commands _(starting with "$")_ throughout the rest of the workshop should be run in this tab. You may want to resize it upwards to make it larger.
 
+At this point you can restart the Cloud9 IDE terminal session to ensure that the kublectl completion is enabled. Once a new terminal window is opened, type $ kubectl get nodes.
+
 One last step is required so that the Cloud9 IDE uses the assigned IAM Instance profile. Open the "AWS Cloud9" menu, go to "Preferences", go to "AWS Settings", and disable "AWS managed temporary credentials" as depicted in the diagram here:
 
 image:cloud9-disable-temp-credentials.png[]

--- a/01-path-basics/101-start-here/scripts/lab-ide-build.sh
+++ b/01-path-basics/101-start-here/scripts/lab-ide-build.sh
@@ -11,10 +11,14 @@
 # Install jq
 sudo yum -y install jq
 
+# Install bash-completion
+sudo yum install ash-completion
+
 # Install kubectl
 curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
 chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-source <(kubectl completion bash)
+echo "source <(kubectl completion bash)" >> ~/.bashrc
+. ~/.bashrc
 
 # Install kops
 curl -LO https://github.com/kubernetes/kops/releases/download/$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)/kops-linux-amd64

--- a/01-path-basics/101-start-here/scripts/lab-ide-build.sh
+++ b/01-path-basics/101-start-here/scripts/lab-ide-build.sh
@@ -18,7 +18,6 @@ sudo yum install bash-completion -y
 curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
 chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 echo "source <(kubectl completion bash)" >> ~/.bashrc
-. ~/.bashrc
 
 # Install kops
 curl -LO https://github.com/kubernetes/kops/releases/download/$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)/kops-linux-amd64

--- a/01-path-basics/101-start-here/scripts/lab-ide-build.sh
+++ b/01-path-basics/101-start-here/scripts/lab-ide-build.sh
@@ -12,7 +12,7 @@
 sudo yum -y install jq
 
 # Install bash-completion
-sudo yum install ash-completion
+sudo yum install bash-completion -y
 
 # Install kubectl
 curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl


### PR DESCRIPTION
*Description of changes: bash-completion not installed within the IDE. Added this package and also source the bash completion for K8s in to .bashrc. All of these changes were made to lab-ide-build.sh

The ide will need to be restarted to enable the kubectl completion. Have tried sourcing the bashrc, but it seems not to work. 

Will update the documentation to instruct restart of the IDE.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
