### PR TITLE
Fixes to whitespace in curl output

### DIFF
--- a/01-path-basics/103-kubernetes-concepts/readme.adoc
+++ b/01-path-basics/103-kubernetes-concepts/readme.adoc
@@ -215,7 +215,7 @@ Verify that the pod came up fine (ensure nothing else is running on port 8088):
 
 	$ kubectl -n default port-forward $(kubectl -n default get pod -l name=nginx-pod -o jsonpath='{.items[0].metadata.name}') 8088:80
 
-From a new terminal window run:
+From a new terminal window, test Nginx by running:
 
 	$ curl http://localhost:8088/
 	<!DOCTYPE html>
@@ -234,12 +234,12 @@ From a new terminal window run:
 	<h1>Welcome to nginx!</h1>
 	<p>If you see this page, the nginx web server is successfully installed and
 	working. Further configuration is required.</p>
-	
+
 	<p>For online documentation and support please refer to
 	<a href="http://nginx.org/">nginx.org</a>.<br/>
 	Commercial support is available at
 	<a href="http://nginx.com/">nginx.com</a>.</p>
-	
+
 	<p><em>Thank you for using nginx.</em></p>
 	</body>
 	</html>

--- a/01-path-basics/103-kubernetes-concepts/readme.adoc
+++ b/01-path-basics/103-kubernetes-concepts/readme.adoc
@@ -726,7 +726,7 @@ If rolling back to a specific revision then enter:
 
 Run the following command to delete the Deployment:
 
-	$ kubectl delete -f templates/deployment.yaml
+	$ kubectl delete -f deployment.yaml
 	deployment "nginx-deployment" deleted
 
 == Service

--- a/01-path-basics/103-kubernetes-concepts/readme.adoc
+++ b/01-path-basics/103-kubernetes-concepts/readme.adoc
@@ -234,12 +234,10 @@ From a new terminal window, test Nginx by running:
 	<h1>Welcome to nginx!</h1>
 	<p>If you see this page, the nginx web server is successfully installed and
 	working. Further configuration is required.</p>
-
 	<p>For online documentation and support please refer to
 	<a href="http://nginx.org/">nginx.org</a>.<br/>
 	Commercial support is available at
 	<a href="http://nginx.com/">nginx.com</a>.</p>
-
 	<p><em>Thank you for using nginx.</em></p>
 	</body>
 	</html>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes to whitespace in the curl output that was breaking the markdown code section into small parts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
