### PR TITLE
Fixed broken indentation in pod.yaml

### DIFF
--- a/01-path-basics/103-kubernetes-concepts/readme.adoc
+++ b/01-path-basics/103-kubernetes-concepts/readme.adoc
@@ -195,7 +195,7 @@ Each resource in Kubernetes can be defined using a configuration file. For examp
 	      name: nginx-pod
 	  spec:
 	    containers:
-	  - name: nginx
+	    - name: nginx
 	      image: nginx:latest
 	      ports:
 	      - containerPort: 80


### PR DESCRIPTION
*Issue:* 

Line 8 of the nginx pod.yaml wasn't indented properly, which caused the following error to occur:

Admin:~/environment $ kubectl apply -f pod.yaml
error: error converting YAML to JSON: yaml: line 8: did not find expected key

*Description of changes:*

Added 2 space indentation to line 8 to fix the yaml.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
