### PR TITLE
Fixed invalid selector

### DIFF
--- a/04-path-security-and-networking/405-ingress-controllers/templates/skipper-ingress-daemonset.yaml
+++ b/04-path-security-and-networking/405-ingress-controllers/templates/skipper-ingress-daemonset.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      application: skipper-ingress
+      component: ingress
   updateStrategy:
     type: RollingUpdate
   template:


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
As per
https://github.com/zalando-incubator/kube-ingress-aws-controller/commit/af27ae14df75eaff95ba2d03cbd5efffdacd5111
Fixed invalid selector, should be component:ingress

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
