### PR TITLE
Improved commands for "Install Istio"

### DIFF
--- a/02-path-working-with-clusters/202-service-mesh/readme.adoc
+++ b/02-path-working-with-clusters/202-service-mesh/readme.adoc
@@ -239,7 +239,7 @@ you'll need to download Istio. Istio can also automatically inject the sidecar; 
 https://istio.io/docs/setup/kubernetes/quick-start.html[Istio quick start]
 
     curl -L https://git.io/getLatestIstio | sh -
-    cd istio-0.2.10
+    cd istio-*
     export PATH=$PWD/bin:$PATH
 
 You should now be able to run the `istioctl` CLI


### PR DESCRIPTION
Thank you for awesome docs 👍 

# What is this

When I'm trying `202: Leveraging a Service Mesh` some error occurred like this.

```sh
ec2-user:~/environment $ cd istio-0.2.10
bash: cd: istio-0.2.10: No such file or directory
```

Because `istio-0.6.0` is latest version.

```sh
ec2-user:~/environment $ cd istio-*
```

So I fixed it using by wildcard.

Thanks 🌟 