### PR TITLE
403-admission-policy kube validation update

### DIFF
--- a/04-path-security-and-networking/403-admission-policy/readme.adoc
+++ b/04-path-security-and-networking/403-admission-policy/readme.adoc
@@ -321,7 +321,7 @@ To verify that your policy is working, create separate test pods.
 
 ```yaml
 kind: Pod
-version: v1
+apiVersion: v1
 metadata:
   name: nginx
   labels:
@@ -340,7 +340,7 @@ controller in action, you can leave it with the fake ID.
 
 ```yaml
 kind: Pod
-version: v1
+apiVersion: v1
 metadata:
   name: amazon-linux-pod
   labels:


### PR DESCRIPTION
Ensure pod descriptions pass kube validation.

After setting up kube1.8 and running thru tutorial front-to-back, found one more bug.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
