### PR TITLE
Misc fixups found during Kubecon workshop

### DIFF
--- a/01-path-basics/103-kubernetes-concepts/readme.adoc
+++ b/01-path-basics/103-kubernetes-concepts/readme.adoc
@@ -1399,7 +1399,7 @@ No resource limits.
 +
 . Create a Deployment in this new Namespace using a configuration file:
 +
-  $ deployment-namespace.yaml
+  $ cat deployment-namespace.yaml
 	apiVersion: extensions/v1beta1
 	kind: Deployment
 	metadata:
@@ -1446,7 +1446,7 @@ Alternatively, a namespace can be created using `kubectl` as well.
 
 . Create a Deployment:
 
-	$ kubectl -n dev2 apply -f templates/deployment.yaml
+	$ kubectl -n dev2 apply -f deployment.yaml
 	deployment "nginx-deployment-ns" created
 
 . Get Deployments in the newly created Namespace:
@@ -1634,6 +1634,8 @@ Note, how CPU and memory resources have incremented values.
 
 https://github.com/kubernetes/kubernetes/issues/55433[kubernetes#55433] provide more details on how an explicit CPU resource is not needed to create a Pod with ResourceQuota.
 
+$ kubectl delete quota/quota
+$ kubectl delete quota/quota2
 
 You are now ready to continue on with the workshop!
 

--- a/02-path-working-with-clusters/202-service-mesh/readme.adoc
+++ b/02-path-working-with-clusters/202-service-mesh/readme.adoc
@@ -158,6 +158,10 @@ If you haven't already deployed the "`hello-world`" application, deploy it now.
     kubectl apply -f https://raw.githubusercontent.com/linkerd/linkerd-examples/master/\
     k8s-daemonset/k8s/hello-world.yml
 
+Delete the previous linkerd Daemonset, as we're going to update the ConfigMap and install a new one:
+
+    $ kubectl delete ds/l5d
+
 Deploy the linkerd ingress so we can access the application externally.
 
     $ kubectl apply -f https://raw.githubusercontent.com/linkerd/linkerd-examples/master/\

--- a/02-path-working-with-clusters/203-cluster-upgrades/readme.adoc
+++ b/02-path-working-with-clusters/203-cluster-upgrades/readme.adoc
@@ -14,7 +14,7 @@ with 1.6.10 version and perform an automatic rolling upgrade to 1.7.2 using kops
 
 === Create cluster
 
-Review steps to create link:../prereqs.adoc[prereqs] nad make sure `KOPS_STATE_STORE` and `AWS_AVAILABILITY_ZONES` environment variables are set. More details about creating a cluster are at link:../cluster-install[Create Kubernetes cluster using kops].
+Review steps to create link:../prereqs.adoc[prereqs] and make sure `KOPS_STATE_STORE` and `AWS_AVAILABILITY_ZONES` environment variables are set. More details about creating a cluster are at link:../cluster-install[Create Kubernetes cluster using kops].
 
 In this chapter, we'll create a Kubernetes 1.6.10 version cluster as shown:
 

--- a/02-path-working-with-clusters/204-cluster-logging-with-EFK/readme.adoc
+++ b/02-path-working-with-clusters/204-cluster-logging-with-EFK/readme.adoc
@@ -16,7 +16,7 @@ In terms of architecture, Fluentd is deployed as a DaemonSet with the CloudWatch
 
 == Prerequisites
 
-This chapter uses a cluster with 3 master nodes and 5 worker nodes as described here: link:../../01-path-basics/102-your-first-cluster#single-master-cluster[single master cluster].
+This chapter uses a cluster with 3 master nodes and 5 worker nodes as described here: link:../cluster-install#multi-master-multi-node-multi-az-gossip-based-cluster[multi-master, multi-node gossip based cluster].
 
 All configuration files for this chapter are in the `02-path-working-with-clusters/204-cluster-logging-with-EFK` directory. Make sure you change to that directory before giving any commands in this chapter.
 

--- a/04-path-security-and-networking/405-ingress-controllers/readme.adoc
+++ b/04-path-security-and-networking/405-ingress-controllers/readme.adoc
@@ -36,7 +36,7 @@ First, apply the initial setup commands:
 
 RBAC roles, or Role Based Access Control, are methods for controlling access to resources based on roles and permissions of individual users. RBAC must be enabled on the api server with the flag, `--authorization-mode=RBAC`. A `Role` can be used to restrict access to a single namespace. Alternatively, a `ClusterRole` can apply access permissions to a particular namespace or across all namespaces. In addition, `RoleBinding` binds the permissions granted by a role to a single user or set of users. `ClusterRoleBinding` can grant these permissions cluster wide and across all namespaces.
 
-To configure the Nginx Ingress Controller with RBAC roles use the following command:
+To configure the Nginx Ingress Controller without RBAC roles use the following command:
 
 	curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/without-rbac.yaml | kubectl apply -f -
 


### PR DESCRIPTION
Fixed `cat deployment` command.
Fixed path to `deployment.yaml` file.
Ensure quotas are torn down at end of section (this prevented Linkerd
from booting in a subsequent section).
Teardown Linkerd DaemonSet prior to starting up Linkerd Ingress.
Fix cluster URL in EKS section.
Other misc fixes.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
