### PR TITLE
Fix manual namespace deployment path

### DIFF
--- a/01-path-basics/103-kubernetes-concepts/readme.adoc
+++ b/01-path-basics/103-kubernetes-concepts/readme.adoc
@@ -1446,7 +1446,7 @@ Alternatively, a namespace can be created using `kubectl` as well.
 
 . Create a Deployment:
 
-	$ kubectl -n dev2 apply -f templates/deployment.yaml
+	$ kubectl -n dev2 apply -f deployment.yaml
 	deployment "nginx-deployment-ns" created
 
 . Get Deployments in the newly created Namespace:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fixes the path to `deployment.yaml` when manually creating the namespace deployment


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
