### PR TITLE
Update docs: use `kubectl get service` instead of `kubectl get svc`

### DIFF
--- a/01-path-basics/103-kubernetes-concepts/readme.adoc
+++ b/01-path-basics/103-kubernetes-concepts/readme.adoc
@@ -861,7 +861,7 @@ Run the following command to create the service:
 Get more details about the service:
 
 ```
-$ kubectl get svc
+$ kubectl get service
 NAME           TYPE           CLUSTER-IP       EXTERNAL-IP        PORT(S)        AGE
 echo-service   LoadBalancer   100.66.161.199   ad0b47976b7fe...   80:30125/TCP   40s
 kubernetes     ClusterIP      100.64.0.1       <none>             443/TCP        1h


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- These docs seem to try to use long names for things rather than
  short names. The shortened `svc` is only referred to once on this
  page - in this example - and it was immediately jarring to me having
  just read about "services" - I asked myself "what's 'svc'?".


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
