### PR TITLE
Fixed order of arguments for kubectl exec.

### DIFF
--- a/01-path-basics/103-kubernetes-concepts/readme.adoc
+++ b/01-path-basics/103-kubernetes-concepts/readme.adoc
@@ -165,7 +165,7 @@ Logs from the pod can be obtained (a fresh nginx does not have logs - check agai
 This command will open a TTY to a shell in your pod:
 
     $ kubectl get pods
-    $ kubectl exec -it <pod-name> /bin/bash
+    $ kubectl exec <pod-name> -it /bin/bash
 
 This opens a bash shell and allows you to look around the filesystem of the container.
 


### PR DESCRIPTION
Otherwise error message 'error: expected 'exec POD_NAME COMMAND [ARG1] [ARG2] ... [ARGN]'.' is encountered.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
