### PR TITLE
Fix skipper-ingress-daemonset.yaml

### DIFF
--- a/04-path-security-and-networking/405-ingress-controllers/templates/skipper-ingress-daemonset.yaml
+++ b/04-path-security-and-networking/405-ingress-controllers/templates/skipper-ingress-daemonset.yaml
@@ -16,6 +16,7 @@ spec:
       name: skipper-ingress
       labels:
         component: ingress
+    spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress


### PR DESCRIPTION
*Description of changes:*

Yaml was not validating, this is fixed in upstream in https://github.com/zalando-incubator/kube-ingress-aws-controller/pull/107

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
