### PR TITLE
use stable api versions for resource which have been promoted to GA

### DIFF
--- a/01-path-basics/103-kubernetes-concepts/readme.adoc
+++ b/01-path-basics/103-kubernetes-concepts/readme.adoc
@@ -542,12 +542,15 @@ A "`desired state`", such as 4 replicas of a pod, can be described in a Deployme
 The folowing example will create a Deployment with 3 replicas of NGINX base image. Let's begin with the template:
 
   $ cat deployment.yaml
-	apiVersion: extensions/v1beta1
+	apiVersion: apps/v1
 	kind: Deployment # kubernetes object type
 	metadata:
 	  name: nginx-deployment # deployment name
 	spec:
 	  replicas: 3 # number of replicas
+	  selector:
+	    matchLabels:
+	      app: nginx
 	  template:
 	    metadata:
 	      labels:
@@ -723,12 +726,15 @@ Pods belong to a service by using a loosely-coupled model where labels are attac
 Let's create a Deployment first that will create 3 replicas of a pod:
 
   $ cat echo-deployment.yaml
-	apiVersion: extensions/v1beta1
+	apiVersion: apps/v1
 	kind: Deployment
 	metadata:
 	  name: echo-deployment
 	spec:
 	  replicas: 3
+	  selector:
+	    matchLabels:
+	      app: echo-pod
 	  template:
 	    metadata:
 	      labels:
@@ -940,6 +946,10 @@ The folowing is an example DaemonSet that runs a Prometheus container. Let's beg
 	metadata:
 	  name: prometheus-daemonset
 	spec:
+	  selector:
+	    matchLabels:
+	      tier: monitoring
+	      name: prometheus-exporter
 	  template:
 	    metadata:
 	      labels:
@@ -1407,6 +1417,9 @@ No resource limits.
 	  namespace: dev
 	spec:
 	  replicas: 3
+	  selector:
+	    matchLabels:
+	      app: nginx
 	  template:
 	    metadata:
 	      labels:

--- a/01-path-basics/103-kubernetes-concepts/templates/daemonset.yaml
+++ b/01-path-basics/103-kubernetes-concepts/templates/daemonset.yaml
@@ -1,8 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: prometheus-daemonset
 spec:
+  selector:
+    matchLabels:
+      tier: monitoring
+      name: prometheus-exporter
   template:
     metadata:
       labels:

--- a/01-path-basics/103-kubernetes-concepts/templates/deployment-namespace.yaml
+++ b/01-path-basics/103-kubernetes-concepts/templates/deployment-namespace.yaml
@@ -1,18 +1,21 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment-ns
   namespace: dev
 spec:
-  replicas: 3 
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
   template:
     metadata:
       labels:
-        app: nginx 
+        app: nginx
     spec:
       containers:
-      - name: nginx 
+      - name: nginx
         image: nginx:1.12.1
-        ports: 
+        ports:
         - containerPort: 80
         - containerPort: 443

--- a/01-path-basics/103-kubernetes-concepts/templates/deployment.yaml
+++ b/01-path-basics/103-kubernetes-concepts/templates/deployment.yaml
@@ -1,17 +1,20 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
 spec:
-  replicas: 3 
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
   template:
     metadata:
       labels:
-        app: nginx 
+        app: nginx
     spec:
       containers:
-      - name: nginx 
+      - name: nginx
         image: nginx:1.12.1
-        ports: 
+        ports:
         - containerPort: 80
         - containerPort: 443

--- a/01-path-basics/103-kubernetes-concepts/templates/echo-deployment.yaml
+++ b/01-path-basics/103-kubernetes-concepts/templates/echo-deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: echo-deployment
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: echo-pod
   template:
     metadata:
       labels:

--- a/01-path-basics/103-kubernetes-concepts/templates/echo.yaml
+++ b/01-path-basics/103-kubernetes-concepts/templates/echo.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: echo-deployment
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: echo-pod
   template:
     metadata:
       labels:

--- a/01-path-basics/103-kubernetes-concepts/templates/replicaset.yaml
+++ b/01-path-basics/103-kubernetes-concepts/templates/replicaset.yaml
@@ -1,17 +1,20 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: nginx-replicaset
 spec:
-  replicas: 3 
+  replicas: 3
+  selector:
+    matchLabels:
+      name: nginx-replica
   template:
     metadata:
       labels:
         name: nginx-replica
     spec:
       containers:
-      - name: nginx-replica 
-        image: nginx:1.12.1 
+      - name: nginx-replica
+        image: nginx:1.12.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80

--- a/02-path-working-with-clusters/201-cluster-monitoring/templates/heapster/grafana.yaml
+++ b/02-path-working-with-clusters/201-cluster-monitoring/templates/heapster/grafana.yaml
@@ -1,10 +1,14 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: monitoring-grafana
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      task: monitoring
+      k8s-app: grafana
   template:
     metadata:
       labels:

--- a/02-path-working-with-clusters/201-cluster-monitoring/templates/heapster/heapster-rbac.yaml
+++ b/02-path-working-with-clusters/201-cluster-monitoring/templates/heapster/heapster-rbac.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: heapster
 roleRef:

--- a/02-path-working-with-clusters/201-cluster-monitoring/templates/heapster/heapster.yaml
+++ b/02-path-working-with-clusters/201-cluster-monitoring/templates/heapster/heapster.yaml
@@ -4,13 +4,17 @@ metadata:
   name: heapster
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: heapster
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      task: monitoring
+      k8s-app: heapster
   template:
     metadata:
       labels:

--- a/02-path-working-with-clusters/201-cluster-monitoring/templates/heapster/influxdb.yaml
+++ b/02-path-working-with-clusters/201-cluster-monitoring/templates/heapster/influxdb.yaml
@@ -1,10 +1,14 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: monitoring-influxdb
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      task: monitoring
+      k8s-app: influxdb
   template:
     metadata:
       labels:

--- a/02-path-working-with-clusters/201-cluster-monitoring/templates/prometheus/grafana-bundle.yaml
+++ b/02-path-working-with-clusters/201-cluster-monitoring/templates/prometheus/grafana-bundle.yaml
@@ -5595,13 +5595,16 @@ data:
         "url": "http://prometheus-operated.monitoring.svc:9090"
     }
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana
   namespace: monitoring
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
   template:
     metadata:
       labels:

--- a/02-path-working-with-clusters/201-cluster-monitoring/templates/prometheus/prometheus-bundle.yaml
+++ b/02-path-working-with-clusters/201-cluster-monitoring/templates/prometheus/prometheus-bundle.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: monitoring
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus-operator
@@ -16,7 +16,7 @@ subjects:
   name: prometheus-operator
   namespace: monitoring
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus-operator
@@ -76,7 +76,7 @@ metadata:
   name: prometheus-operator
   namespace: monitoring
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -85,6 +85,9 @@ metadata:
   namespace: monitoring
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: prometheus-operator
   template:
     metadata:
       labels:

--- a/02-path-working-with-clusters/201-cluster-monitoring/templates/prometheus/prometheus.yaml
+++ b/02-path-working-with-clusters/201-cluster-monitoring/templates/prometheus/prometheus.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kube-state-metrics
   namespace: monitoring
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kube-state-metrics
@@ -23,7 +23,7 @@ rules:
   - replicasets
   verbs: ["list", "watch"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kube-state-metrics
@@ -72,12 +72,15 @@ spec:
     targetPort: 10252
     protocol: TCP
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: node-exporter
   namespace: monitoring
 spec:
+  selector:
+    matchLabels:
+      app: node-exporter
   template:
     metadata:
       labels:
@@ -139,13 +142,16 @@ spec:
   selector:
     app: node-exporter
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-state-metrics
   namespace: monitoring
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: kube-state-metrics
   template:
     metadata:
       labels:

--- a/02-path-working-with-clusters/204-cluster-logging-with-EFK/templates/fluentd-ds.yaml
+++ b/02-path-working-with-clusters/204-cluster-logging-with-EFK/templates/fluentd-ds.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluentd
@@ -12,6 +12,9 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 1
+  selector:
+    matchLabels:
+      k8s-app: fluentd
   template:
     metadata:
       labels:

--- a/02-path-working-with-clusters/204-cluster-logging-with-EFK/templates/fluentd-role-binding.yaml
+++ b/02-path-working-with-clusters/204-cluster-logging-with-EFK/templates/fluentd-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: fluentd-read

--- a/02-path-working-with-clusters/204-cluster-logging-with-EFK/templates/fluentd-role.yaml
+++ b/02-path-working-with-clusters/204-cluster-logging-with-EFK/templates/fluentd-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: fluentd-read

--- a/02-path-working-with-clusters/205-cluster-autoscaling/templates/2-10-autoscaler.yaml
+++ b/02-path-working-with-clusters/205-cluster-autoscaling/templates/2-10-autoscaler.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cluster-autoscaler

--- a/02-path-working-with-clusters/205-cluster-autoscaling/templates/dummy-resource-offers.yaml
+++ b/02-path-working-with-clusters/205-cluster-autoscaling/templates/dummy-resource-offers.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
     - port: 8080
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: greeter

--- a/03-path-application-development/302-app-discovery/templates/app.yml
+++ b/03-path-application-development/302-app-discovery/templates/app.yml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Service
-metadata: 
+metadata:
   name: name-service
-spec: 
-  selector: 
+spec:
+  selector:
     app: name-pod
   ports:
     - port: 8080
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: name-rs
@@ -27,15 +27,15 @@ spec:
 ---
 apiVersion: v1
 kind: Service
-metadata: 
+metadata:
   name: greeter-service
-spec: 
-  selector: 
+spec:
+  selector:
     app: greeter-pod
   ports:
     - port: 8080
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: greeter-rs
@@ -54,10 +54,10 @@ spec:
 ---
 apiVersion: v1
 kind: Service
-metadata: 
+metadata:
   name: webapp-service
-spec: 
-  selector: 
+spec:
+  selector:
     app: webapp-pod
   ports:
     - name: web
@@ -65,12 +65,15 @@ spec:
       targetPort: 8080
   type: LoadBalancer
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: webapp-rs
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: webapp-pod
   template:
     metadata:
       labels:

--- a/03-path-application-development/303-app-update/readme.adoc
+++ b/03-path-application-development/303-app-update/readme.adoc
@@ -33,12 +33,15 @@ Let's look at these two deployment strategies.
 
 All existing pods are killed before the new ones are created. The configuration file looks like:
 
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: app-recreate
     spec:
       replicas: 5
+      selector:
+        matchLabels:
+          name: app-recreate
       strategy:
         type: Recreate
       template:
@@ -193,12 +196,15 @@ Two optional properties can be used to define how rolling update is performed:
 
 The configuration file looks like:
 
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: app-rolling
     spec:
       replicas: 5
+      selector:
+        matchLabels:
+          name: app-rolling
       strategy:
         type: RollingUpdate
         rollingUpdate:
@@ -389,12 +395,16 @@ Two Deployments with image for different versions are used togther. Both Deploym
 
 Let's look at version `v1` of the Deployment:
 
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: app-v1
     spec:
       replicas: 2
+      selector:
+        matchLabels:
+          name: app
+          version: v1
       template:
         metadata:
           labels:
@@ -411,12 +421,16 @@ It uses `arungupta/app-upgrade:v1` image. It has two labels `name: app` and `ver
 
 Let's look at version `v2` of the Deployment:
 
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: app-v2
     spec:
       replicas: 2
+      selector:
+        matchLabels:
+          name: app
+          version: v2
       template:
         metadata:
           labels:

--- a/03-path-application-development/303-app-update/templates/app-recreate.yaml
+++ b/03-path-application-development/303-app-update/templates/app-recreate.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app-recreate
 spec:
   replicas: 5
+  selector:
+    matchLabels:
+      name: app-recreate
   strategy:
     type: Recreate
   template:

--- a/03-path-application-development/303-app-update/templates/app-rolling.yaml
+++ b/03-path-application-development/303-app-update/templates/app-rolling.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app-rolling
 spec:
   replicas: 5
+  selector:
+    matchLabels:
+      name: app-rolling
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/03-path-application-development/303-app-update/templates/app-v1.yaml
+++ b/03-path-application-development/303-app-update/templates/app-v1.yaml
@@ -1,9 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app-v1
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      name: app
+      version: v1
   template:
     metadata:
       labels:

--- a/03-path-application-development/303-app-update/templates/app-v2.yaml
+++ b/03-path-application-development/303-app-update/templates/app-v2.yaml
@@ -1,9 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app-v2
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      name: app
+      version: v2
   template:
     metadata:
       labels:

--- a/03-path-application-development/305-app-tracing-with-jaeger-and-x-ray/x-ray/templates/daemonsetxray.yaml
+++ b/03-path-application-development/305-app-tracing-with-jaeger-and-x-ray/x-ray/templates/daemonsetxray.yaml
@@ -1,8 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: xray
 spec:
+  selector:
+    matchLabels:
+      tier: monitoring
+      name: xray
   template:
     metadata:
       labels:

--- a/03-path-application-development/305-app-tracing-with-jaeger-and-x-ray/x-ray/templates/flaskyxray-deployment.yaml
+++ b/03-path-application-development/305-app-tracing-with-jaeger-and-x-ray/x-ray/templates/flaskyxray-deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: flaskxray-deployment 
+  name: flaskxray-deployment
 spec:
   replicas: 5
+  selector:
+    matchLabels:
+      app: flaskxray-pod
   template:
     metadata:
       labels:
@@ -18,8 +21,8 @@ spec:
           value: 172.17.0.1:2000
         - name: AWS_XRAY_CONTEXT_MISSING
           value: LOG_ERROR
-        imagePullPolicy: IfNotPresent 
-        ports: 
+        imagePullPolicy: IfNotPresent
+        ports:
         - containerPort: 5000
         resources:
             requests:

--- a/03-path-application-development/305-app-tracing-with-jaeger-and-x-ray/x-ray/templates/nodejs-microservices.yaml
+++ b/03-path-application-development/305-app-tracing-with-jaeger-and-x-ray/x-ray/templates/nodejs-microservices.yaml
@@ -1,19 +1,22 @@
 apiVersion: v1
 kind: Service
-metadata: 
+metadata:
   name: name-service
-spec: 
-  selector: 
+spec:
+  selector:
     app: name-pod
   ports:
     - port: 8080
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: name-deployment
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: name-pod
   template:
     metadata:
       labels:
@@ -32,20 +35,23 @@ spec:
 ---
 apiVersion: v1
 kind: Service
-metadata: 
+metadata:
   name: greeter-service
-spec: 
-  selector: 
+spec:
+  selector:
     app: greeter-pod
   ports:
     - port: 8080
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: greeter-deployment
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: greeter-pod
   template:
     metadata:
       labels:
@@ -64,10 +70,10 @@ spec:
 ---
 apiVersion: v1
 kind: Service
-metadata: 
+metadata:
   name: webapp-service
-spec: 
-  selector: 
+spec:
+  selector:
     app: webapp-pod
   ports:
     - name: web
@@ -75,12 +81,15 @@ spec:
       targetPort: 8080
   type: LoadBalancer
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: webapp-deployment
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: webapp-pod
   template:
     metadata:
       labels:

--- a/03-path-application-development/306-app-management-with-helm/sample/templates/db-deployment.yaml
+++ b/03-path-application-development/306-app-management-with-helm/sample/templates/db-deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mysql-deployment
 spec:
   replicas: {{ .Values.db.replicas }}
+  selector:
+    matchLabels:
+      app: mysql-pod
   template:
     metadata:
       labels:

--- a/03-path-application-development/306-app-management-with-helm/sample/templates/webapp-deployment.yaml
+++ b/03-path-application-development/306-app-management-with-helm/sample/templates/webapp-deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: webapp-deployment
 spec:
   replicas: {{ .Values.webapp.replicas }}
+  selector:
+    matchLabels:
+      app: webapp-pod
   template:
     metadata:
       labels:

--- a/03-path-application-development/307-statefulsets-and-pvs/templates/mysql-statefulset.yaml
+++ b/03-path-application-development/307-statefulsets-and-pvs/templates/mysql-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: mysql
@@ -165,4 +165,3 @@ spec:
       resources:
         requests:
           storage: 10Gi
-

--- a/03-path-application-development/309-deploying-a-chart-repository/sample/templates/db-deployment.yaml
+++ b/03-path-application-development/309-deploying-a-chart-repository/sample/templates/db-deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mysql-deployment
 spec:
   replicas: {{ .Values.db.replicas }}
+  selector:
+    matchLabels:
+      app: mysql-pod
   template:
     metadata:
       labels:

--- a/03-path-application-development/309-deploying-a-chart-repository/sample/templates/webapp-deployment.yaml
+++ b/03-path-application-development/309-deploying-a-chart-repository/sample/templates/webapp-deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: webapp-deployment
 spec:
   replicas: {{ .Values.webapp.replicas }}
+  selector:
+    matchLabels:
+      app: webapp-pod
   template:
     metadata:
       labels:

--- a/03-path-application-development/309-deploying-a-chart-repository/sample/templates/webapp-service.yaml
+++ b/03-path-application-development/309-deploying-a-chart-repository/sample/templates/webapp-service.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
-metadata: 
+metadata:
   name: webapp
-spec: 
-  selector: 
+spec:
+  selector:
     app: webapp-pod
   ports:
     - port: {{ .Values.webapp.port }}

--- a/03-path-application-development/310-chaos-engineering/templates/app.yaml
+++ b/03-path-application-development/310-chaos-engineering/templates/app.yaml
@@ -1,19 +1,22 @@
 apiVersion: v1
 kind: Service
-metadata: 
+metadata:
   name: name-service
-spec: 
-  selector: 
+spec:
+  selector:
     app: name-pod
   ports:
     - port: 8080
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: name-rs
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: name-pod
   template:
     metadata:
       labels:
@@ -27,20 +30,23 @@ spec:
 ---
 apiVersion: v1
 kind: Service
-metadata: 
+metadata:
   name: greeter-service
-spec: 
-  selector: 
+spec:
+  selector:
     app: greeter-pod
   ports:
     - port: 8080
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: greeter-rs
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: greeter-pod
   template:
     metadata:
       labels:
@@ -54,10 +60,10 @@ spec:
 ---
 apiVersion: v1
 kind: Service
-metadata: 
+metadata:
   name: webapp-service
-spec: 
-  selector: 
+spec:
+  selector:
     app: webapp-pod
   ports:
     - name: web
@@ -65,12 +71,15 @@ spec:
       targetPort: 8080
   type: LoadBalancer
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: webapp-rs
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: webapp-pod
   template:
     metadata:
       labels:

--- a/04-path-security-and-networking/401-configmaps-and-secrets/templates/vault-reviewer-rbac.yaml
+++ b/04-path-security-and-networking/401-configmaps-and-secrets/templates/vault-reviewer-rbac.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: role-tokenreview-binding
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: vault-reviewer
-  namespace: default 
+  namespace: default

--- a/04-path-security-and-networking/402-authentication-and-authorization/templates/deployment-with-vault.yaml
+++ b/04-path-security-and-networking/402-authentication-and-authorization/templates/deployment-with-vault.yaml
@@ -1,5 +1,5 @@
-apiVersion: apps/v1beta1
-kind: Deployment 
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: vault-sidecar
 spec:
@@ -11,7 +11,7 @@ spec:
     spec:
       serviceAccountName: vault-auth
       containers:
-        - name: aws-cli 
+        - name: aws-cli
           image: cgswong/aws:aws
           command:
             - "sleep"
@@ -31,5 +31,5 @@ spec:
               mountPath: "/root/.aws/"
       volumes:
         - name: app-secrets
-          emptyDir: 
+          emptyDir:
             medium: "Memory"

--- a/04-path-security-and-networking/402-authentication-and-authorization/templates/kube2iam-ds.yaml
+++ b/04-path-security-and-networking/402-authentication-and-authorization/templates/kube2iam-ds.yaml
@@ -1,10 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube2iam
   labels:
     app: kube2iam
 spec:
+  selector:
+    matchLabels:
+      name: kube2iam
   template:
     metadata:
       labels:
@@ -15,10 +18,10 @@ spec:
         - image: jtblin/kube2iam:0.8.1
           name: kube2iam
           args:
-            - "--auto-discover-base-arn" 
+            - "--auto-discover-base-arn"
             - "--host-interface=cbr0"
-            - "--host-ip=$(HOST_IP)"  
-            - "--iptables=true"      
+            - "--host-ip=$(HOST_IP)"
+            - "--iptables=true"
           env:
             - name: HOST_IP
               valueFrom:

--- a/04-path-security-and-networking/403-admission-policy/readme.adoc
+++ b/04-path-security-and-networking/403-admission-policy/readme.adoc
@@ -174,7 +174,7 @@ OPA interact with kubernetes.
 **opa-admission-controller-deployment.yaml**:
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -182,6 +182,9 @@ metadata:
   name: opa
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: opa
   template:
     metadata:
       labels:

--- a/04-path-security-and-networking/404-network-policies/calico/templates/calico-update.yaml
+++ b/04-path-security-and-networking/404-network-policies/calico/templates/calico-update.yaml
@@ -41,7 +41,7 @@ data:
     }
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico
   labels:
@@ -75,7 +75,7 @@ metadata:
     role.kubernetes.io/networking: "1"
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico
   labels:
@@ -93,7 +93,7 @@ subjects:
 # as the Calico CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: calico-node
   namespace: kube-system
@@ -216,7 +216,7 @@ spec:
 ---
 # This manifest deploys the Calico policy controller on Kubernetes.
 # See https://github.com/projectcalico/k8s-policy
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: calico-policy-controller
@@ -227,6 +227,10 @@ metadata:
 spec:
   # The policy controller can only have a single active instance.
   replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: calico-policy-controller
+      role.kubernetes.io/networking: "1"
   template:
     metadata:
       name: calico-policy-controller
@@ -270,7 +274,7 @@ spec:
               value: "true"
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: k8s-ec2-srcdst
   labels:
@@ -296,7 +300,7 @@ metadata:
     role.kubernetes.io/networking: "1"
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: k8s-ec2-srcdst
   labels:
@@ -310,7 +314,7 @@ subjects:
   name: k8s-ec2-srcdst
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: k8s-ec2-srcdst

--- a/04-path-security-and-networking/404-network-policies/weavenet/templates/weavenet-update.yaml
+++ b/04-path-security-and-networking/404-network-policies/weavenet/templates/weavenet-update.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: weave-net
@@ -34,7 +34,7 @@ metadata:
     role.kubernetes.io/networking: "1"
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: weave-net
@@ -50,7 +50,7 @@ subjects:
     name: weave-net
     namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: weave-net
@@ -75,7 +75,7 @@ rules:
     verbs:
       - create
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: weave-net
@@ -92,7 +92,7 @@ subjects:
     name: weave-net
     namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: weave-net
@@ -101,6 +101,10 @@ metadata:
     role.kubernetes.io/networking: "1"
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      name: weave-net
+      role.kubernetes.io/networking: "1"
   template:
     metadata:
       labels:

--- a/04-path-security-and-networking/405-ingress-controllers/templates/alb-ingress-controller.yaml
+++ b/04-path-security-and-networking/405-ingress-controllers/templates/alb-ingress-controller.yaml
@@ -1,7 +1,7 @@
 # Application Load Balancer (ALB) Ingress Controller Deployment Manifest.
 # This manifest details sensible defaults for deploying an ALB Ingress Controller.
 # GitHub: https://github.com/coreos/alb-ingress-controller
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/04-path-security-and-networking/405-ingress-controllers/templates/app.yml
+++ b/04-path-security-and-networking/405-ingress-controllers/templates/app.yml
@@ -1,19 +1,22 @@
 apiVersion: v1
 kind: Service
-metadata: 
+metadata:
   name: name-service
-spec: 
-  selector: 
+spec:
+  selector:
     app: name-pod
   ports:
     - port: 8080
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: name-rs
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: name-pod
   template:
     metadata:
       labels:
@@ -27,20 +30,23 @@ spec:
 ---
 apiVersion: v1
 kind: Service
-metadata: 
+metadata:
   name: greeter-service
-spec: 
-  selector: 
+spec:
+  selector:
     app: greeter-pod
   ports:
     - port: 8080
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: greeter-rs
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: greeter-pod
   template:
     metadata:
       labels:
@@ -54,10 +60,10 @@ spec:
 ---
 apiVersion: v1
 kind: Service
-metadata: 
+metadata:
   name: webapp-service
-spec: 
-  selector: 
+spec:
+  selector:
     app: webapp-pod
   ports:
     - name: web
@@ -65,12 +71,15 @@ spec:
       targetPort: 8080
   type: NodePort
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: webapp-rs
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: webapp-pod
   template:
     metadata:
       labels:

--- a/04-path-security-and-networking/405-ingress-controllers/templates/kube-aws-ingress-controller-deployment.yaml
+++ b/04-path-security-and-networking/405-ingress-controllers/templates/kube-aws-ingress-controller-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-ingress-aws-controller
@@ -7,6 +7,9 @@ metadata:
     component: ingress
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      component: ingress
   template:
     metadata:
       labels:

--- a/04-path-security-and-networking/405-ingress-controllers/templates/sample-app-v1.yaml
+++ b/04-path-security-and-networking/405-ingress-controllers/templates/sample-app-v1.yaml
@@ -1,9 +1,13 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: demo-app-v1
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      application: demo
+      version: v1
   template:
     metadata:
       labels:

--- a/04-path-security-and-networking/405-ingress-controllers/templates/sample-app-v2.yaml
+++ b/04-path-security-and-networking/405-ingress-controllers/templates/sample-app-v2.yaml
@@ -1,9 +1,13 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: demo-app-v2
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      application: demo
+      version: v2
   template:
     metadata:
       labels:

--- a/04-path-security-and-networking/405-ingress-controllers/templates/skipper-ingress-daemonset.yaml
+++ b/04-path-security-and-networking/405-ingress-controllers/templates/skipper-ingress-daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: skipper-ingress

--- a/04-path-security-and-networking/406-coredns/templates/coredns-kops.yaml
+++ b/04-path-security-and-networking/406-coredns/templates/coredns-kops.yaml
@@ -4,7 +4,7 @@ metadata:
   name: coredns
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -22,7 +22,7 @@ rules:
   - list
   - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:
@@ -55,7 +55,7 @@ data:
         cache 30
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: coredns

--- a/04-path-security-and-networking/406-coredns/templates/coredns-minikube.yaml
+++ b/04-path-security-and-networking/406-coredns/templates/coredns-minikube.yaml
@@ -4,7 +4,7 @@ metadata:
   name: coredns
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -22,7 +22,7 @@ rules:
   - list
   - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:
@@ -55,7 +55,7 @@ data:
         cache 30
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: coredns


### PR DESCRIPTION
DaemonSet, Deployment, ReplicaSet - are stable since kubernetes **v1.9** and are in `apps/v1`
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.9.md#apps

`rbac.authorization.k8s.io` API group is GA and **v1** since kubernetes **v1.8**
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.8.md#sig-auth

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
