### PR TITLE
Fixed Template (app.yaml). Selectors were missing.

### DIFF
--- a/03-path-application-development/302-app-discovery/templates/app.yml
+++ b/03-path-application-development/302-app-discovery/templates/app.yml
@@ -14,6 +14,9 @@ metadata:
   name: name-rs
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: name-pod
   template:
     metadata:
       labels:
@@ -41,6 +44,9 @@ metadata:
   name: greeter-rs
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: greeter-pod
   template:
     metadata:
       labels:


### PR DESCRIPTION
app.yaml was missing `selector` in to places.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
