### PR TITLE
Section 103 doc edits

### DIFF
--- a/01-path-basics/103-kubernetes-concepts/readme.adoc
+++ b/01-path-basics/103-kubernetes-concepts/readme.adoc
@@ -19,7 +19,7 @@ This chapter uses a cluster with 3 master nodes and 5 worker nodes as described 
 All configuration files for this chapter are in the `01-path-basics/103-kubernetes-concepts/templates` directory.
 Please be sure to `cd` into that directory before running the commands below.
 
-    $ cd 01-path-basics/103-kubernetes-concepts/templates
+    $ cd ~/environment/aws-workshop-for-kubernetes/01-path-basics/103-kubernetes-concepts/templates
 
 == Display Nodes
 
@@ -339,7 +339,7 @@ Watch the status of the Pod:
 
 `OOMKilled` shows that the container was terminated because it ran out of memory.
 
-In `pod-resources2.yaml`, change the value of `spec.containers[].resources.limits.memory` to `300Mi`. Delete the existing Pod, and create a new one:
+In `pod-resources2.yaml`, confirm that the value of `spec.containers[].resources.limits.memory` is `300Mi`. Delete the existing Pod, and create a new one:
 
 	$ kubectl delete -f pod-resources1.yaml
 	pod "wildfly-pod" deleted
@@ -1568,8 +1568,14 @@ It shows only three replicas are available.
 +
 . More details can be found:
 +
-	$ kubectl get deployment/nginx-deployment -o jsonpath={.status.conditions[].message}
-	Deployment does not have minimum availability.
+	$ kubectl describe deployment nginx-deployment
+        ...
+        Conditions:
+          Type             Status  Reason
+          ----             ------  ------
+          Progressing      True    NewReplicaSetAvailable
+          Available        False   MinimumReplicasUnavailable
+          ReplicaFailure   True    FailedCreate
 +
 The current reason is displayed in the output.
 


### PR DESCRIPTION
A few cleanup items in the docs:

- Clarify full path to templates directory
- the pod-resource2.yaml already has the correct memory setting, so no need to change it
- method for confirming why deployment did not work after quota change needs updating

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
