### PR TITLE
create-kubeconfig.sh and .bashrc

### DIFF
--- a/01-path-basics/101-start-here/scripts/create-kubeconfig.sh
+++ b/01-path-basics/101-start-here/scripts/create-kubeconfig.sh
@@ -1,0 +1,19 @@
+# Create kubeconfig script
+#title           create-kubeconfig.sh
+#description     This script will create a kubeconfig file based on the EKS cluster k8s-workshop.
+#author          @buzzsurfr
+#contributors    @buzzsurfr @dalbhanj @cloudymind
+#date            2018-06-07
+#version         0.2
+#usage           curl -sSL https://s3.amazonaws.com/aws-kubernetes-artifacts/v0.5/create-kubeconfig.sh | bash -s stable
+#==============================================================================
+
+# Download kubeconfig template
+mkdir $HOME/.kube
+aws s3 cp s3://aws-kubernetes-artifacts/v0.5/config-k8s-workshop $HOME/.kube/config
+
+# Configure based on EKS cluster k8s-workshop
+sed -i -e "s#<endpoint-url>#$(aws eks describe-cluster --name k8s-workshop --query cluster.endpoint --output text)#g" $HOME/.kube/config
+sed -i -e "s#<base64-encoded-ca-cert>#$(aws eks describe-cluster --name k8s-workshop --query cluster.certificateAuthority.data --output text)#g" $HOME/.kube/config
+sed -i -e "s#<cluster-name>#k8s-workshop#g" $HOME/.kube/config
+sed -i -e "s#<role-arn>#$EKS_SERVICE_ROLE#g" $HOME/.kube/config

--- a/01-path-basics/101-start-here/scripts/lab-ide-build.sh
+++ b/01-path-basics/101-start-here/scripts/lab-ide-build.sh
@@ -52,15 +52,15 @@ export EKS_SECURITY_GROUPS=$(aws cloudformation describe-stacks --stack-name $AW
 export EKS_SERVICE_ROLE=$(aws cloudformation describe-stacks --stack-name $AWS_MASTER_STACK | jq -r '.Stacks[0].Outputs[]|select(.OutputKey=="EksServiceRoleArn")|.OutputValue')
 
 # Persist lab variables
-echo "AWS_AVAILABILITY_ZONES=$AWS_AVAILABILITY_ZONES" >> ~/.bash_profile
-echo "KOPS_STATE_STORE=$KOPS_STATE_STORE" >> ~/.bash_profile
-echo "export AWS_AVAILABILITY_ZONES KOPS_STATE_STORE" >> ~/.bash_profile
+echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION" >> ~/.bashrc
+echo "AWS_AVAILABILITY_ZONES=$AWS_AVAILABILITY_ZONES" >> ~/.bashrc
+echo "KOPS_STATE_STORE=$KOPS_STATE_STORE" >> ~/.bashrc
 
 # Persist EKS variables
-echo "EKS_VPC_ID=$EKS_VPC_ID" >> ~/.bash_profile
-echo "EKS_SUBNET_IDS=$EKS_SUBNET_IDS" >> ~/.bash_profile
-echo "EKS_SECURITY_GROUPS=$EKS_SECURITY_GROUPS" >> ~/.bash_profile
-echo "EKS_SERVICE_ROLE=$EKS_SERVICE_ROLE" >> ~/.bash_profile
+echo "EKS_VPC_ID=$EKS_VPC_ID" >> ~/.bashrc
+echo "EKS_SUBNET_IDS=$EKS_SUBNET_IDS" >> ~/.bashrc
+echo "EKS_SECURITY_GROUPS=$EKS_SECURITY_GROUPS" >> ~/.bashrc
+echo "EKS_SERVICE_ROLE=$EKS_SERVICE_ROLE" >> ~/.bashrc
 
 # EKS-Optimized AMI
 if [ "$AWS_DEFAULT_REGION" == "us-east-1" ]; then
@@ -68,7 +68,7 @@ if [ "$AWS_DEFAULT_REGION" == "us-east-1" ]; then
 elif [ "$AWS_DEFAULT_REGION" == "us-west-2" ]; then
   export EKS_WORKER_AMI=ami-73a6e20b
 fi
-echo "EKS_WORKER_AMI=$EKS_WORKER_AMI" >> ~/.bash_profile
+echo "EKS_WORKER_AMI=$EKS_WORKER_AMI" >> ~/.bashrc
 
 # Create SSH key
 ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa


### PR DESCRIPTION
*Issue #, if available:*
Fixes #477 

*Description of changes:*

- Adds create-kubeconfig.sh (which was in S3 bucket but not present on repo)
- Changes environment variables to store in .bashrc instead of .bash_profile (which led to #477)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
