### PR TITLE
create-kubeconfig.sh prepares .kube/config => updated readme.adoc

### DIFF
--- a/01-path-basics/102-your-first-cluster/readme.adoc
+++ b/01-path-basics/102-your-first-cluster/readme.adoc
@@ -54,7 +54,7 @@ Once the cluster has moved to the `ACTIVE` state, download and run the `create-k
     chmod +x create-kubeconfig.sh && \
     . ./create-kubeconfig.sh
 
-This will create a configuration file at `$HOME/.kube/config-k8s-workshop` and update the necessary environment variable for default access.
+This will create a configuration file at `$HOME/.kube/config` and update the necessary environment variable for default access.
 
 === Create the worker nodes
 


### PR DESCRIPTION
s3://aws-kubernetes-artifacts/v0.5/create-kubeconfig.sh will create a configuration file at `$HOME/.kube/config`. Updated documentation.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
