### PR TITLE
Update CFN to use correct, persisted environment variable for stackname.

### DIFF
--- a/01-path-basics/101-start-here/scripts/lab-ide-build.sh
+++ b/01-path-basics/101-start-here/scripts/lab-ide-build.sh
@@ -54,6 +54,7 @@ export EKS_SERVICE_ROLE=$(aws cloudformation describe-stacks --stack-name $AWS_M
 # Persist lab variables
 echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION" >> ~/.bashrc
 echo "AWS_AVAILABILITY_ZONES=$AWS_AVAILABILITY_ZONES" >> ~/.bashrc
+echo "AWS_MASTER_STACK=$AWS_MASTER_STACK" >> ~/.bashrc
 echo "KOPS_STATE_STORE=$KOPS_STATE_STORE" >> ~/.bashrc
 
 # Persist EKS variables

--- a/01-path-basics/102-your-first-cluster/readme.adoc
+++ b/01-path-basics/102-your-first-cluster/readme.adoc
@@ -66,7 +66,7 @@ To launch your worker nodes, run the following CloudFormation CLI command:
       --stack-name k8s-workshop-worker-nodes \
       --template-url https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-06-05/amazon-eks-nodegroup.yaml \
       --capabilities "CAPABILITY_IAM" \
-      --parameters "[{\"ParameterKey\": \"KeyName\", \"ParameterValue\": \"${AWS_STACK_NAME}\"},
+      --parameters "[{\"ParameterKey\": \"KeyName\", \"ParameterValue\": \"${AWS_MASTER_STACK}\"},
                      {\"ParameterKey\": \"NodeImageId\", \"ParameterValue\": \"${EKS_WORKER_AMI}\"},
                      {\"ParameterKey\": \"ClusterName\", \"ParameterValue\": \"k8s-workshop\"},
                      {\"ParameterKey\": \"NodeGroupName\", \"ParameterValue\": \"k8s-workshop-nodegroup\"},
@@ -74,7 +74,7 @@ To launch your worker nodes, run the following CloudFormation CLI command:
                      {\"ParameterKey\": \"VpcId\", \"ParameterValue\": \"${EKS_VPC_ID}\"},
                      {\"ParameterKey\": \"Subnets\", \"ParameterValue\": \"${EKS_SUBNET_IDS}\"}]"
 
-The `AWS_STACK_NAME`, `EKS_WORKER_AMI`, `EKS_VPC_ID`, `EKS_SUBNET_IDS`, and `EKS_SECURITY_GROUPS` environment variables should have been set during the link:../101-start-here[Cloud9 Environment Setup].
+The `AWS_MASTER_STACK`, `EKS_WORKER_AMI`, `EKS_VPC_ID`, `EKS_SUBNET_IDS`, and `EKS_SECURITY_GROUPS` environment variables should have been set during the link:../101-start-here[Cloud9 Environment Setup].
 
 Node provisioning usually takes less than 5 minutes. You can query the status of your cluster with the following command. When your cluster status is `CREATE_COMPLETE`, you can proceed.
 


### PR DESCRIPTION
*Issue #, if available:*
#486 

*Description of changes:*
Updates CloudFormation "Worker Nodes" command to use `AWS_MASTER_STACK` environment variable and persist that variable after the build script runs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
