### PR TITLE
#475 Added Instructions to Use AWS Secrets Manager within 401

### DIFF
--- a/04-path-security-and-networking/401-configmaps-and-secrets/images/sec_mgr_app/.dockerignore
+++ b/04-path-security-and-networking/401-configmaps-and-secrets/images/sec_mgr_app/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/04-path-security-and-networking/401-configmaps-and-secrets/images/sec_mgr_app/Dockerfile
+++ b/04-path-security-and-networking/401-configmaps-and-secrets/images/sec_mgr_app/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:carbon
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+RUN npm install
+# If you are building your code for production
+# RUN npm install --only=production
+# Bundle app source
+COPY . .
+
+CMD [ "npm", "start" ]

--- a/04-path-security-and-networking/401-configmaps-and-secrets/images/sec_mgr_app/package.json
+++ b/04-path-security-and-networking/401-configmaps-and-secrets/images/sec_mgr_app/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "docker_web_app",
+  "version": "1.0.0",
+  "description": "Node.js on Docker",
+  "author": "First Last <first.last@example.com>",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "aws-sdk": "latest",
+    "npm": "^6.1.0"
+  }
+}

--- a/04-path-security-and-networking/401-configmaps-and-secrets/images/sec_mgr_app/package.json
+++ b/04-path-security-and-networking/401-configmaps-and-secrets/images/sec_mgr_app/package.json
@@ -2,13 +2,14 @@
   "name": "docker_web_app",
   "version": "1.0.0",
   "description": "Node.js on Docker",
-  "author": "First Last <first.last@example.com>",
+  "author": "Paavan Mistry",
   "main": "server.js",
   "scripts": {
     "start": "node server.js"
   },
   "dependencies": {
     "aws-sdk": "latest",
+    "dotenv": "^6.0.0",
     "npm": "^6.1.0"
   }
 }

--- a/04-path-security-and-networking/401-configmaps-and-secrets/images/sec_mgr_app/server.js
+++ b/04-path-security-and-networking/401-configmaps-and-secrets/images/sec_mgr_app/server.js
@@ -1,11 +1,14 @@
 'use strict';
 
+require('dotenv').config();
+
 var AWS = require('aws-sdk'),
-              endpoint = "https://secretsmanager.us-west-2.amazonaws.com",
-              region = "us-west-2",
-              secretName = "testsecret",
+              endpoint = process.env.ENDPOINT,
+              region = process.env.REGION,
+              secretName = process.env.SECRETNAME,
               secret = "",
               binarySecretData = "";
+
 
 // Constants
 var client = new AWS.SecretsManager({
@@ -36,11 +39,5 @@ client.getSecretValue({SecretId: secretName}, function(err, data) {
   }
 
   // Your code goes here.
-  console.log(`Secret retrieved from AWS SecretsManager: ${secretName} is ${secret}`);
+  console.log(`Secret retrieved from AWS SecretsManager: The Secret ${secretName} has SecretString ${secret}`);
 });
-
-
-
-
-
-

--- a/04-path-security-and-networking/401-configmaps-and-secrets/images/sec_mgr_app/server.js
+++ b/04-path-security-and-networking/401-configmaps-and-secrets/images/sec_mgr_app/server.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var AWS = require('aws-sdk'),
+              endpoint = "https://secretsmanager.us-west-2.amazonaws.com",
+              region = "us-west-2",
+              secretName = "testsecret",
+              secret = "",
+              binarySecretData = "";
+
+// Constants
+var client = new AWS.SecretsManager({
+  endpoint: endpoint,
+  region: region
+});
+
+
+// App
+client.getSecretValue({SecretId: secretName}, function(err, data) {
+  if(err) {
+      if(err.code === 'ResourceNotFoundException')
+          console.log("The requested secret " + secretName + " was not found");
+      else if(err.code === 'InvalidRequestException')
+          console.log("The request was invalid due to: " + err.message);
+      else if(err.code === 'InvalidParameterException')
+          console.log("The request had invalid params: " + err.message);
+  }
+  else {
+      // Decrypted secret using the associated KMS CMK
+      // Depending on whether the secret was a string or binary, one of these fields will be populated
+      if(data.SecretString !== "") {
+          secret = data.SecretString;
+//          console.log(secret);
+      } else {
+          binarySecretData = data.SecretBinary;
+      }
+  }
+
+  // Your code goes here.
+  console.log(`Secret retrieved from AWS SecretsManager: ${secretName} is ${secret}`);
+});
+
+
+
+
+
+

--- a/04-path-security-and-networking/401-configmaps-and-secrets/readme.adoc
+++ b/04-path-security-and-networking/401-configmaps-and-secrets/readme.adoc
@@ -769,8 +769,8 @@ Check the logs of the Pod:
 
 Clean up:
 
-  - $ kubectl delete -f templates/pod-secretsmanager.yaml
-  - $ aws secretsmanager delete-secret --secret-id testsecret --region us-west-2
+  - `$ kubectl delete -f templates/pod-secretsmanager.yaml`
+  - `$ aws secretsmanager delete-secret --secret-id testsecret --region us-west-2`
   - Delete IAM role policy updates for AWS Secrets Manager
 
 == Secrets using Vault

--- a/04-path-security-and-networking/401-configmaps-and-secrets/readme.adoc
+++ b/04-path-security-and-networking/401-configmaps-and-secrets/readme.adoc
@@ -678,9 +678,9 @@ This shows that the Java application has been able to read both the NAME and GRE
 
 == Secrets using AWS Secrets Manager
 
-This section will show how to create a secret using AWS Secrets Manager and access it in a Pod.
+This section will show how to create a secret using https://aws.amazon.com/secrets-manager/[AWS Secrets Manager] and access the secret in a Pod.
 
-AWS Secrets Manager enables you to easily rotate, manage, and retrieve database credentials, API keys, and other secrets throughout their lifecycle. The service integrates with KMS, which uses a https://aws.amazon.com/blogs/security/aws-key-management-service-now-offers-fips-140-2-validated-cryptographic-modules-enabling-easier-adoption-of-the-service-for-regulated-workloads/[FIPS 140-2 validated Hardware Security Module], to provide robust key management controls for protection of the secret. It also integrates with AWS IAM and AWS CloudTrail to provide fine-grained access, audit and alerting integration.
+AWS Secrets Manager enables you to easily rotate, manage, and retrieve database credentials, API keys, and other secrets throughout their lifecycle. The service integrates with KMS, which uses a https://aws.amazon.com/blogs/security/aws-key-management-service-now-offers-fips-140-2-validated-cryptographic-modules-enabling-easier-adoption-of-the-service-for-regulated-workloads/[FIPS 140-2 validated Hardware Security Module], to provide robust key management controls to secure the secret. AWS Secrets Manager also integrates with AWS IAM and AWS CloudTrail to provide fine-grained access, audit and alerting integration.
 
 === Update the IAM role for EKS or `kops` Kubernetes Cluster
 

--- a/04-path-security-and-networking/401-configmaps-and-secrets/readme.adoc
+++ b/04-path-security-and-networking/401-configmaps-and-secrets/readme.adoc
@@ -678,13 +678,11 @@ This shows that the Java application has been able to read both the NAME and GRE
 
 == Secrets using AWS Secrets Manager
 
-This section will show how to create a secret using https://aws.amazon.com/secrets-manager/[AWS Secrets Manager] and access the secret in a Pod.
+In this section, we will create a secret using https://aws.amazon.com/secrets-manager/[AWS Secrets Manager] in the region of choice, and access the secret in a Node.js application deployed within Kubernetes pod. AWS Secrets Manager is available in https://docs.aws.amazon.com/general/latest/gr/rande.html#asm_region[most AWS regions].
 
 AWS Secrets Manager enables you to easily rotate, manage, and retrieve database credentials, API keys, and other secrets throughout their lifecycle. The service integrates with KMS, which uses a https://aws.amazon.com/blogs/security/aws-key-management-service-now-offers-fips-140-2-validated-cryptographic-modules-enabling-easier-adoption-of-the-service-for-regulated-workloads/[FIPS 140-2 validated Hardware Security Module], to provide robust key management controls to secure the secret. AWS Secrets Manager also integrates with AWS IAM and AWS CloudTrail to provide fine-grained access, audit and alerting integration.
 
 === Update the IAM role for EKS or `kops` Kubernetes Cluster
-
-In this guide, we will create the secret in the US-West (Oregon) `us-west-2` region. AWS Secrets Manager is available in most AWS regions
 
 ==== EKS Kubernetes Cluster
 EC2 worker nodes use `NodeInstanceRole` created in Step 3 of the https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html[EKS Getting Started guide]. This role must be updated to allow the worked nodes to read the secrets from Secrets Manager.
@@ -733,19 +731,23 @@ and click it. In the `Permissions` tab, expand the inline policy for `nodes.exam
 
 === Create secrets
 
-. Create a secret key-value pair using https://docs.aws.amazon.com/cli/latest/reference/secretsmanager/create-secret.html[AWS Secrets Manager CLI].
+. Create a secret key-value pair using https://docs.aws.amazon.com/cli/latest/reference/secretsmanager/create-secret.html[AWS Secrets Manager CLI]. Replace `<SECRETNAME>` and `<REGION>` with your preference.
 
-  aws secretsmanager create-secret --name testsecret --description "EKS/kops Demo Secret" --secret-string [{"testkey":"testvalue"}] --region us-west-2
+  aws secretsmanager create-secret --name <SECRETNAME> --description "EKS/kops Demo Secret" --secret-string [{"testkey1":"testvalue1"},{"testkey2":"testvalue2"}] --region <REGION>
 
-. Get the value of created secret using https://docs.aws.amazon.com/cli/latest/reference/secretsmanager/get-secret-value.html[GetSecretValue] API call
+. Get the value of created secret using https://docs.aws.amazon.com/cli/latest/reference/secretsmanager/get-secret-value.html[GetSecretValue] API call.
 
-  aws secretsmanager get-secret-value --secret-id testsecret --region us-west-2
+  aws secretsmanager get-secret-value --secret-id <SECRETNAME> --region <REGION>
+
+. For the selected `<REGION>`, AWS Secrets Manager `<ENDPOINT>` can be determined from https://docs.aws.amazon.com/general/latest/gr/rande.html#asm_region[AWS Documentation].
+
+. Note the `ENDPOINT`, `REGION` and `SECRETNAME` values. They will be passed as environment variables in a `.yaml` file described in the next section.
 
 === Consume secrets in a Pod
 
-The directory images/sec_mgr_app contains a Node.js application that reads secrets from AWS Secrets Manager from the US-West (Oregon) `us-west-2` region. This application is then packaged as a Pod and deployed in the cluster.
+The Github repository directory `images/sec_mgr_app` contains a Node.js sample application that reads a secret from AWS Secrets Manager from specified region. This application is then packaged as a Pod and deployed in the cluster.
 
-The Pod configuration is shown below:
+The Pod configuration is shown below. The `ENDPOINT`, `REGION` and `SECRETNAME` variables are passed as environment variables to the docker image. Change the values of these environment variables to match the values used during creation of secret in AWS Secrets Manager.
 
     apiVersion: v1
     kind: Pod
@@ -755,22 +757,29 @@ The Pod configuration is shown below:
       containers:
       - name: pod-secretsmanager
         image: paavanmistry/node-aws-sm-demo:latest
+        env:
+          - name: ENDPOINT
+            value: "https://secretsmanager.us-west-2.amazonaws.com"
+          - name: REGION
+            value: "us-west-2"
+          - name: SECRETNAME
+            value: "sm-demo-secret"
       restartPolicy: Never
 
 Create the Pod:
 
   $ kubectl apply -f templates/pod-secretsmanager.yaml
-  pod "pod-parameter-store" configured
+  pod "pod-secretsmanager" configured
 
 Check the logs of the Pod:
 
   $ kubectl logs pod-secretsmanager
-  Secret retrieved from AWS SecretsManager: testsecret is {testkey}:{testvalue}
+  Secret retrieved from AWS SecretsManager: The Secret <SECRETNAME> is [{testkey1}:{testvalue1},{testkey2:testvalue2}]
 
 Clean up:
 
   - `$ kubectl delete -f templates/pod-secretsmanager.yaml`
-  - `$ aws secretsmanager delete-secret --secret-id testsecret --region us-west-2`
+  - `$ aws secretsmanager delete-secret --secret-id $SECRETNAME --region $REGION`
   - Delete IAM role policy updates for AWS Secrets Manager
 
 == Secrets using Vault

--- a/04-path-security-and-networking/401-configmaps-and-secrets/readme.adoc
+++ b/04-path-security-and-networking/401-configmaps-and-secrets/readme.adoc
@@ -678,9 +678,97 @@ This shows that the Java application has been able to read both the NAME and GRE
 
 == Secrets using AWS Secrets Manager
 
-=== Update the IAM role
+This section will show how to create a secret using AWS Secrets Manager and access it in a Pod.
+
+AWS Secrets Manager enables you to easily rotate, manage, and retrieve database credentials, API keys, and other secrets throughout their lifecycle. The service integrates with KMS, which uses a https://aws.amazon.com/blogs/security/aws-key-management-service-now-offers-fips-140-2-validated-cryptographic-modules-enabling-easier-adoption-of-the-service-for-regulated-workloads/[FIPS 140-2 validated Hardware Security Module], to provide robust key management controls for protection of the secret. It also integrates with AWS IAM and AWS CloudTrail to provide fine-grained access, audit and alerting integration.
+
+=== Update the IAM role for EKS or `kops` Kubernetes Cluster
+
+==== EKS Kubernetes Cluster
+EC2 worker nodes use `NodeInstanceRole` created in Step 3 of the https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html[EKS Getting Started guide]. This role must be updated to allow the worked nodes to read the secrets from Secrets Manager.
+
+In the IAM Console, click `roles` and type `NodeInstanceRole` and click it. In the Permissions tab, expand the inline policy and click `Edit policy`. Add the `secretsManager:GetSecretValue` permission to the policy so the policy looks similar to the one below.
+
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "secretsmanager:GetSecretValue",
+                    "secretsmanager:DescribeSecret"
+                ],
+                "Resource": [
+                    "arn:aws:secretsmanager:<region>:<account-id>:secret:<secret-name>"
+                ]
+            }
+        ]
+    }
+
+==== `kops` Kubernetes Cluster
+
+EC2 worker nodes use an instance profile to allow the EC2 node instances to access other AWS services. This role must be updated to allow the worker nodes to read the secrets from Secrets Manager.
+
+In the IAM Console click `roles` and type `nodes` into the search box. Find the `nodes.example.cluster.k8s.local` role
+and click it. In the Permissions tab, expand the inline policy for `nodes.example.cluster.k8s.local` and click
+`Edit policy`.
+
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "secretsmanager:GetSecretValue",
+                    "secretsmanager:DescribeSecret"
+                ],
+                "Resource": [
+                    "arn:aws:secretsmanager:<region>:<account-id>:secret:<secret-name>"
+                ]
+            }
+        ]
+    }
+
 === Create secrets
+
+. Create a secret key-value pair using https://docs.aws.amazon.com/cli/latest/reference/secretsmanager/create-secret.html[AWS Secrets Manager CLI].
+
+  aws secretsmanager create-secret --name testsecret --description "EKS/kops Demo Secret" --secret-string [{"testkey":"testvalue"}] --region us-west-2
+
+. Get the value of created secret using https://docs.aws.amazon.com/cli/latest/reference/secretsmanager/get-secret-value.html[GetSecretValue] API call
+
+  aws secretsmanager get-secret-value --secret-id testsecret --region us-west-2
+
 === Consume secrets in a Pod
+
+The directory images/sec_mgr_app contains a Node.js application that reads secrets from AWS Secrets Manager from the US-West (Oregon) `us-west-2` region. This application is then packaged as a Pod and deployed in the cluster.
+
+The Pod configuration is shown below:
+
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: pod-secretsmanager
+    spec:
+      containers:
+      - name: pod-secretsmanager
+        image: paavanmistry/node-aws-sm-demo:latest
+      restartPolicy: Never
+
+Create the Pod:
+
+  $ kubectl apply -f templates/pod-secretsmanager.yaml
+  pod "pod-parameter-store" configured
+
+Check the logs of the Pod:
+
+  $ kubectl logs pod-secretsmanager
+  Secret retrieved from AWS SecretsManager: testsecret is {testkey}:{testvalue}
+
+Clean up:
+
+  $ kubectl delete -f templates/pod-secretsmanager.yaml
+  $ aws secretsmanager delete-secret --secret-id testsecret --region us-west-2
 
 == Secrets using Vault
 

--- a/04-path-security-and-networking/401-configmaps-and-secrets/readme.adoc
+++ b/04-path-security-and-networking/401-configmaps-and-secrets/readme.adoc
@@ -684,6 +684,8 @@ AWS Secrets Manager enables you to easily rotate, manage, and retrieve database 
 
 === Update the IAM role for EKS or `kops` Kubernetes Cluster
 
+In this guide, we will create the secret in the US-West (Oregon) `us-west-2` region. AWS Secrets Manager is available in most AWS regions
+
 ==== EKS Kubernetes Cluster
 EC2 worker nodes use `NodeInstanceRole` created in Step 3 of the https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html[EKS Getting Started guide]. This role must be updated to allow the worked nodes to read the secrets from Secrets Manager.
 
@@ -699,7 +701,7 @@ In the IAM Console, click `roles` and type `NodeInstanceRole` and click it. In t
                     "secretsmanager:DescribeSecret"
                 ],
                 "Resource": [
-                    "arn:aws:secretsmanager:<region>:<account-id>:secret:<secret-name>"
+                    "arn:aws:secretsmanager:us-west-2:<account-id>:secret:<secret-name>"
                 ]
             }
         ]
@@ -723,7 +725,7 @@ and click it. In the `Permissions` tab, expand the inline policy for `nodes.exam
                     "secretsmanager:DescribeSecret"
                 ],
                 "Resource": [
-                    "arn:aws:secretsmanager:<region>:<account-id>:secret:<secret-name>"
+                    "arn:aws:secretsmanager:us-west-2:<account-id>:secret:<secret-name>"
                 ]
             }
         ]
@@ -767,8 +769,9 @@ Check the logs of the Pod:
 
 Clean up:
 
-  $ kubectl delete -f templates/pod-secretsmanager.yaml
-  $ aws secretsmanager delete-secret --secret-id testsecret --region us-west-2
+  - $ kubectl delete -f templates/pod-secretsmanager.yaml
+  - $ aws secretsmanager delete-secret --secret-id testsecret --region us-west-2
+  - Delete IAM role policy updates for AWS Secrets Manager
 
 == Secrets using Vault
 

--- a/04-path-security-and-networking/401-configmaps-and-secrets/readme.adoc
+++ b/04-path-security-and-networking/401-configmaps-and-secrets/readme.adoc
@@ -676,6 +676,12 @@ Check the logs of the Pod:
 
 This shows that the Java application has been able to read both the NAME and GREETING secrets from AWS Parameter Store.
 
+== Secrets using AWS Secrets Manager
+
+=== Update the IAM role
+=== Create secrets
+=== Consume secrets in a Pod
+
 == Secrets using Vault
 
 https://www.vaultproject.io/[Hashicorp Vault] is a tool for managing secrets. It secures, stores and tightly controls access to tokens, passwords, certificates, API keys and other secrets.

--- a/04-path-security-and-networking/401-configmaps-and-secrets/readme.adoc
+++ b/04-path-security-and-networking/401-configmaps-and-secrets/readme.adoc
@@ -710,7 +710,7 @@ In the IAM Console, click `roles` and type `NodeInstanceRole` and click it. In t
 EC2 worker nodes use an instance profile to allow the EC2 node instances to access other AWS services. This role must be updated to allow the worker nodes to read the secrets from Secrets Manager.
 
 In the IAM Console click `roles` and type `nodes` into the search box. Find the `nodes.example.cluster.k8s.local` role
-and click it. In the Permissions tab, expand the inline policy for `nodes.example.cluster.k8s.local` and click
+and click it. In the `Permissions` tab, expand the inline policy for `nodes.example.cluster.k8s.local` and click
 `Edit policy`.
 
     {

--- a/04-path-security-and-networking/401-configmaps-and-secrets/templates/pod-secretsmanager.yaml
+++ b/04-path-security-and-networking/401-configmaps-and-secrets/templates/pod-secretsmanager.yaml
@@ -2,10 +2,18 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod-secretsmanager
+  annotations:
+    seccomp.security.alpha.kubernetes.io/pod: docker/default
+    apparmor.security.beta.kubernetes.io/pod: runtime/default
 spec:
+  securityContext:
+    runAsUser:    1337
+    runAsNonRoot: true
   containers:
   - name: pod-secretsmanager
     image: paavanmistry/node-aws-sm-demo:latest
+    securityContext:
+      allowPrivilegeEscalation: false
     env:
       - name: ENDPOINT
         value: "https://secretsmanager.us-west-2.amazonaws.com"

--- a/04-path-security-and-networking/401-configmaps-and-secrets/templates/pod-secretsmanager.yaml
+++ b/04-path-security-and-networking/401-configmaps-and-secrets/templates/pod-secretsmanager.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-secretsmanager
+spec:
+  containers:
+  - name: pod-secretsmanager
+    image: paavanmistry/node-aws-sm-demo:latest
+  restartPolicy: Never

--- a/04-path-security-and-networking/401-configmaps-and-secrets/templates/pod-secretsmanager.yaml
+++ b/04-path-security-and-networking/401-configmaps-and-secrets/templates/pod-secretsmanager.yaml
@@ -6,4 +6,11 @@ spec:
   containers:
   - name: pod-secretsmanager
     image: paavanmistry/node-aws-sm-demo:latest
+    env:
+      - name: ENDPOINT
+        value: "https://secretsmanager.us-west-2.amazonaws.com"
+      - name: REGION
+        value: "us-west-2"
+      - name: SECRETNAME
+        value: "sm-demo-secret"
   restartPolicy: Never


### PR DESCRIPTION
*Issue #475

*Description of changes:
Added guidance to use AWS Secrets Manager in addition to AWS SSM Parameter Store.

Thanks,
-paavan@

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
