### PR TITLE
Re-add kubectl bash completion command to .bashrc

### DIFF
--- a/01-path-basics/101-start-here/scripts/lab-ide-build.sh
+++ b/01-path-basics/101-start-here/scripts/lab-ide-build.sh
@@ -20,6 +20,7 @@ sudo yum install bash-completion -y
 # Install kubectl
 curl -o kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-06-05/bin/linux/amd64/kubectl
 chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+echo "source <(kubectl completion bash)" >> ~/.bashrc
 
 # Install Heptio Authenticator
 curl -o heptio-authenticator-aws https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-06-05/bin/linux/amd64/heptio-authenticator-aws


### PR DESCRIPTION
*Issue #, if available:* #497 

*Description of changes:* re-add line removed from lab-ide-build.sh that adds kubectl bash completion to .bashrc


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
