### PR TITLE
Update readme.adoc

### DIFF
--- a/02-path-working-with-clusters/201-cluster-monitoring/readme.adoc
+++ b/02-path-working-with-clusters/201-cluster-monitoring/readme.adoc
@@ -18,9 +18,9 @@ Heapster is limited to Kuberenetes container metrics, it is not general use. Hea
 
 == Prerequisites
 
-This chapter uses a cluster with 3 master nodes and 5 worker nodes as described here: link:../cluster-install#multi-master-multi-node-multi-az-gossip-based-cluster[multi-master, multi-node gossip based cluster].
+In order to effectively perform the monitoring exercises in this chapter, make sure you have an EKS cluster running based on link:../../01-path-basics/102-your-first-cluster#create-a-kubernetes-cluster-with-eks[Create A Kubernetes Cluster Using EKS].
 
-All configuration files for this chapter are in the `cluster-monitoring` directory. Make sure you change to that directory before giving any commands in this chapter.
+All configuration files for this chapter are in the link:templates[201-cluster-monitoring/templates] directory.
 
 == Kubernetes Dashboard
 

--- a/02-path-working-with-clusters/201-cluster-monitoring/readme.adoc
+++ b/02-path-working-with-clusters/201-cluster-monitoring/readme.adoc
@@ -18,7 +18,7 @@ Heapster is limited to Kuberenetes container metrics, it is not general use. Hea
 
 == Prerequisites
 
-In order to effectively perform the monitoring exercises in this chapter, make sure you have an EKS cluster running based on link:../../01-path-basics/102-your-first-cluster#create-a-kubernetes-cluster-with-eks[Create A Kubernetes Cluster Using EKS].
+In order to perform exercises in this chapter, you'll need to deploy configurations to an EKS cluster.  To create an EKS cluster, use the link:../../01-path-basics/102-your-first-cluster#create-a-kubernetes-cluster-with-eks[AWS CLI] (recommended), or alternatively, link:../../01-path-basics/102-your-first-cluster#alternative-create-a-kubernetes-cluster-with-kops[kops].
 
 All configuration files for this chapter are in the link:templates[201-cluster-monitoring/templates] directory.
 


### PR DESCRIPTION
Fixing links around the reference cluster prereq. Also changed the wording to change to the templates dir, because the actual kubectl commands are executed relative to templates dir, not in it.

https://github.com/aws-samples/aws-workshop-for-kubernetes/issues/434

Fixed issue and some additional clarification on template dir.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
