### PR TITLE
[Fix] - Renamed "AWS_MASTER_STACK" to "AWS_STACK_NAME" when creating

### DIFF
--- a/01-path-basics/102-your-first-cluster/readme.adoc
+++ b/01-path-basics/102-your-first-cluster/readme.adoc
@@ -66,7 +66,7 @@ To launch your worker nodes, run the following CloudFormation CLI command:
       --stack-name k8s-workshop-worker-nodes \
       --template-url https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-06-05/amazon-eks-nodegroup.yaml \
       --capabilities "CAPABILITY_IAM" \
-      --parameters "[{\"ParameterKey\": \"KeyName\", \"ParameterValue\": \"${AWS_MASTER_STACK}\"},
+      --parameters "[{\"ParameterKey\": \"KeyName\", \"ParameterValue\": \"${AWS_STACK_NAME}\"},
                      {\"ParameterKey\": \"NodeImageId\", \"ParameterValue\": \"${EKS_WORKER_AMI}\"},
                      {\"ParameterKey\": \"ClusterName\", \"ParameterValue\": \"k8s-workshop\"},
                      {\"ParameterKey\": \"NodeGroupName\", \"ParameterValue\": \"k8s-workshop-nodegroup\"},


### PR DESCRIPTION
worker nodes

Issues:
Creating worker nodes causes error caused by wrong env used as "KeyName"

Changes:
Renamed "AWS_MASTER_STACK" to "AWS_STACK_NAME"


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
