### PR TITLE
Update readme.adoc

### DIFF
--- a/02-path-working-with-clusters/202-service-mesh/readme.adoc
+++ b/02-path-working-with-clusters/202-service-mesh/readme.adoc
@@ -34,7 +34,7 @@ In this exercise we'll look at a few of the features linkerd provides, such as:
 
 === Create a Kubernetes cluster
 
-In order to perform exercises in this chapter, you'll need to deploy configurations to an EKS cluster. To create an EKS cluster, use the link:../../01-path-basics/102-your-first-cluster#create-a-kubernetes-cluster-with-eks[AWS CLI] (recommended), or alternatively, link:../../01-path-basics/102-your-first-cluster#alternative-create-a-kubernetes-cluster-with-kops[kops].
+In order to perform exercises in this chapter, you’ll need to deploy configurations to a Kubernetes cluster. To create an EKS-based Kubernetes cluster, use the link:../../01-path-basics/102-your-first-cluster#create-a-kubernetes-cluster-with-eks[AWS CLI] (recommended).  If you wish to create a Kubernetes cluster without EKS, you can instead use link:../../01-path-basics/102-your-first-cluster#alternative-create-a-kubernetes-cluster-with-kops[kops].
 
 === Install linkerd
 
@@ -234,7 +234,7 @@ In this exercise we'll look at a few of the features Istio provides, such as:
 
 === Create Kubernetes cluster
 
-In order to perform exercises in this chapter, you'll need to deploy configurations to an EKS cluster. To create an EKS cluster, use the link:../../01-path-basics/102-your-first-cluster#create-a-kubernetes-cluster-with-eks[AWS CLI] (recommended), or alternatively, link:../../01-path-basics/102-your-first-cluster#alternative-create-a-kubernetes-cluster-with-kops[kops].
+In order to perform exercises in this chapter, you’ll need to deploy configurations to a Kubernetes cluster. To create an EKS-based Kubernetes cluster, use the link:../../01-path-basics/102-your-first-cluster#create-a-kubernetes-cluster-with-eks[AWS CLI] (recommended).  If you wish to create a Kubernetes cluster without EKS, you can instead use link:../../01-path-basics/102-your-first-cluster#alternative-create-a-kubernetes-cluster-with-kops[kops].
 
 === Install Istio
 


### PR DESCRIPTION
https://github.com/aws-samples/aws-workshop-for-kubernetes/issues/376

Changing language to emphasize difference between EKS and non-EKS-based K8S on AWS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
