### PR TITLE
Add use of cloudformation wait to cluster creation

### DIFF
--- a/01-path-basics/102-your-first-cluster/readme.adoc
+++ b/01-path-basics/102-your-first-cluster/readme.adoc
@@ -100,7 +100,14 @@ To launch your worker nodes, run the following CloudFormation CLI command:
 
 The `AWS_STACK_NAME`, `EKS_WORKER_AMI`, `EKS_VPC_ID`, `EKS_SUBNET_IDS`, and `EKS_SECURITY_GROUPS` environment variables should have been set during the link:../101-start-here[Cloud9 Environment Setup].
 
-Node provisioning usually takes less than 5 minutes. You can query the status of your cluster with the following command. When your cluster status is `CREATE_COMPLETE`, you can proceed.
+Node provisioning usually takes less than 5 minutes.
+You may execute this command to wait until the create-stack has completed:
+
+    $ aws cloudformation wait stack-update-complete --stack-name k8s-workshop-worker-nodes
+
+Read more about `https://docs.aws.amazon.com/cli/latest/reference/cloudformation/wait/index.html[cloudformation wait, window="_blank"]`.
+
+You can also query the status of your cluster with the following command. When your cluster status is `CREATE_COMPLETE`, you can proceed.
 
     $ aws cloudformation describe-stacks --stack-name k8s-workshop-worker-nodes --query 'Stacks[0].StackStatus' --output text
 


### PR DESCRIPTION
While waiting for the cluster to become available, we can set a single
command that blocks until it's ready, instead of asking the reader to
run the same command multiple times. We leave the manual poll as an
option.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
