### PR TITLE
Minor documentation update

### DIFF
--- a/04-path-security-and-networking/402-authentication-and-authorization/templates/kube2iam-ds.yaml
+++ b/04-path-security-and-networking/402-authentication-and-authorization/templates/kube2iam-ds.yaml
@@ -19,6 +19,8 @@ spec:
           name: kube2iam
           args:
             - "--auto-discover-base-arn"
+           # Set the host network interface to 'eni+' in the case of using 
+           # amazon-vpc-cni-k8s (see https://github.com/jtblin/kube2iam#iptables)
             - "--host-interface=cbr0"
             - "--host-ip=$(HOST_IP)"
             - "--iptables=true"


### PR DESCRIPTION
Minor documentation update

*Issue #, if available (include [keywords](https://help.github.com/articles/closing-issues-using-keywords/) to close issue as applicable, e.g. "fixes <##>"):*

*Description of changes:*

Adds a note of which configuration to use for `kube2iam` for when the user is following the cloud9 template as opposed to the kops template. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
