### PR TITLE
fix for issue 555

### DIFF
--- a/01-path-basics/101-start-here/scripts/lab-ide-build.sh
+++ b/01-path-basics/101-start-here/scripts/lab-ide-build.sh
@@ -23,8 +23,8 @@ chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 echo "source <(kubectl completion bash)" >> ~/.bashrc
 
 # Install Heptio Authenticator
-curl -o heptio-authenticator-aws https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-06-05/bin/linux/amd64/heptio-authenticator-aws
-chmod +x ./heptio-authenticator-aws && sudo mv heptio-authenticator-aws /usr/local/bin/
+curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-06-05/bin/linux/amd64/heptio-authenticator-aws
+chmod +x ./aws-iam-authenticator && sudo mv aws-iam-authenticator /usr/local/bin/
 
 # Install kops
 curl -LO https://github.com/kubernetes/kops/releases/download/$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)/kops-linux-amd64

--- a/01-path-basics/101-start-here/templates/config-k8s-workshop
+++ b/01-path-basics/101-start-here/templates/config-k8s-workshop
@@ -17,7 +17,7 @@ users:
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
-      command: heptio-authenticator-aws
+      command: aws-iam-authenticator
       args:
         - "token"
         - "-i"


### PR DESCRIPTION
https://github.com/aws-samples/aws-workshop-for-kubernetes/issues/555

Renaming auth binary in lab-ide-build and config-k8s-workshop to new name.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
