### PR TITLE
Updating version of the Datadog Cluster Agent to latest

### DIFF
--- a/03-path-application-development/305-app-scaling-custom-metrics/templates/cluster-agent/cluster-agent.yaml
+++ b/03-path-application-development/305-app-scaling-custom-metrics/templates/cluster-agent/cluster-agent.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       serviceAccountName: datadog-cluster-agent
       containers:
-      - image: datadog/cluster-agent:0.10.0
+      - image: datadog/cluster-agent:latest
         imagePullPolicy: Always
         name: datadog-cluster-agent
         env:


### PR DESCRIPTION
*Description of changes:*

We released the [Datadog Cluster Agent 1.0.0](https://www.datadoghq.com/blog/datadog-cluster-agent/) last week, I would like to promote the latest version in the workshop.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
